### PR TITLE
Added input

### DIFF
--- a/include/brickengine/input/input.hpp
+++ b/include/brickengine/input/input.hpp
@@ -1,16 +1,22 @@
 #include <iostream>
 #include <unordered_map>
 
+#include "brickengine/input/player_input.hpp"
+#include "SDL2/SDL.h"
+
 class BrickInput {
 
-private:
-    std::unordered_map<std::string, bool> inputs;
-    // sdl mapped to game
-    std::unordered_map<std::string, std::string> inputMapping;
 public:
-    BrickInput();
-    void setInputMapping(std::unordered_map<std::string, std::string>& gameInput);
+    BrickInput() = default;
+    static BrickInput& getInstance();
+    void setInputMapping(std::unordered_map<SDL_Keycode, PlayerInput>& gameInput);
     void popInput(std::string const input);
     void checkInput(std::string const input);
     void processInput();
+private:
+    // List of mapped inputs
+    std::unordered_map<PlayerInput, bool> inputs;
+    // SDL inputs mapped to game input
+    std::unordered_map<SDL_Keycode, PlayerInput> inputMapping;
+
 };

--- a/include/brickengine/input/input.hpp
+++ b/include/brickengine/input/input.hpp
@@ -10,8 +10,9 @@ public:
     BrickInput() = default;
     static BrickInput& getInstance();
     void setInputMapping(std::unordered_map<SDL_Keycode, PlayerInput>& gameInput);
-    void popInput(std::string const input);
-    void checkInput(std::string const input);
+    //void popInput(PlayerInput const input);
+    //void checkInput(PlayerInput const input);
+    bool remapInput(PlayerInput const input);
     void processInput();
 private:
     // List of mapped inputs

--- a/include/brickengine/input/input.hpp
+++ b/include/brickengine/input/input.hpp
@@ -1,0 +1,16 @@
+#include <iostream>
+#include <unordered_map>
+
+class BrickInput {
+
+private:
+    std::unordered_map<std::string, bool> inputs;
+    // sdl mapped to game
+    std::unordered_map<std::string, std::string> inputMapping;
+public:
+    BrickInput();
+    void setInputMapping(std::unordered_map<std::string, std::string>& gameInput);
+    void popInput(std::string const input);
+    void checkInput(std::string const input);
+    void processInput();
+};

--- a/include/brickengine/input/input.hpp
+++ b/include/brickengine/input/input.hpp
@@ -10,8 +10,9 @@ public:
     BrickInput() = default;
     static BrickInput& getInstance();
     void setInputMapping(std::unordered_map<SDL_Keycode, PlayerInput>& gameInput);
-    //void popInput(PlayerInput const input);
-    //void checkInput(PlayerInput const input);
+    // This function is intended for the UI so the game loop is not affected.
+    void popInput(PlayerInput const input);
+    bool checkInput(PlayerInput const input);
     bool remapInput(PlayerInput const input);
     void processInput();
 private:

--- a/include/brickengine/input/player_input.hpp
+++ b/include/brickengine/input/player_input.hpp
@@ -1,0 +1,38 @@
+#ifndef FILE_PLAYER_INPUT_HPP
+#define FILE_PLAYER_INPUT_HPP
+
+enum PlayerInput {
+    // Player 1
+    PLAYER1_UP,
+    PLAYER1_LEFT,
+    PLAYER1_RIGHT,
+    PLAYER1_DOWN,
+    PLAYER1_SHOOT,
+    PLAYER1_GRAB,
+
+    // Player 2
+    PLAYER2_UP,
+    PLAYER2_LEFT,
+    PLAYER2_RIGHT,
+    PLAYER2_DOWN,
+    PLAYER2_SHOOT,
+    PLAYER2_GRAB,
+    
+    // Player 3
+    PLAYER3_UP,
+    PLAYER3_LEFT,
+    PLAYER3_RIGHT,
+    PLAYER3_DOWN,
+    PLAYER3_SHOOT,
+    PLAYER3_GRAB,
+    
+    // Player 4
+    PLAYER4_UP,
+    PLAYER4_LEFT,
+    PLAYER4_RIGHT,
+    PLAYER4_DOWN,
+    PLAYER4_SHOOT,
+    PLAYER4_GRAB
+};
+
+#endif

--- a/lib/input/input.cpp
+++ b/lib/input/input.cpp
@@ -62,4 +62,15 @@ bool BrickInput::remapInput(PlayerInput input) {
             }
         }
     }
+};
+
+bool BrickInput::checkInput(PlayerInput const input) {
+    if(inputs.count(input))
+        return inputs[input];
+    return false;
+};
+
+void BrickInput::popInput(PlayerInput const input) {
+    if(inputs.count(input))
+        inputs[input] = false;
 }

--- a/lib/input/input.cpp
+++ b/lib/input/input.cpp
@@ -1,6 +1,7 @@
 #include "brickengine/input/input.hpp"
 #include "brickengine/input/player_input.hpp"
 #include "SDL2/SDL.h"
+#include <algorithm>
 
 BrickInput& BrickInput::getInstance() {
     static BrickInput INSTANCE;
@@ -12,11 +13,22 @@ void BrickInput::processInput(){
     while (SDL_PollEvent(&e))
     {
         // Checking if input is mapped.
-        if(inputMapping.find(e.key.keysym.sym) != inputMapping.end()) {
-            if (e.type == SDL_KEYDOWN)
-                inputs[inputMapping[e.key.keysym.sym]] = true;
-            else
-                inputs[inputMapping[e.key.keysym.sym]] = false;
+        if(inputMapping.find(e.key.keysym.sym) != inputMapping.end() && e.key.repeat == 0) {
+            switch(e.type) {
+                case SDL_KEYDOWN:
+                    inputs[inputMapping[e.key.keysym.sym]] = true;
+                    break;
+                case SDL_KEYUP:
+                    inputs[inputMapping[e.key.keysym.sym]] = false;
+                default:
+                    break;
+            }
+            
+        }
+    }
+    for(auto it : inputs) {
+        if(it.second) {
+            std::cout <<  it.first << std::endl;
         }
     }
 };
@@ -27,3 +39,32 @@ void BrickInput::setInputMapping(std::unordered_map<SDL_Keycode, PlayerInput>& g
         inputs[it.second] = false;
     }
 };
+
+bool BrickInput::remapInput(PlayerInput input) {
+    //Search for the old value
+    auto oldInput = std::find_if(inputMapping.begin(),inputMapping.end(),
+                                                [&input](const std::pair<SDL_Keycode, PlayerInput>& value)
+                                               { return value.second == input; });
+    SDL_Event e;
+    while(true) {
+        while(SDL_PollEvent(&e)) {
+            if(e.type == SDL_KEYDOWN) {
+                //Current key matches old key
+                if(e.key.keysym.sym == oldInput->first) {
+                    return true;
+                }
+                //Input is not already used
+                if(inputMapping.count(e.key.keysym.sym) == 0)
+                {
+                    inputMapping[e.key.keysym.sym] = input;
+                    //Removing old key mapping
+                    inputMapping.erase(oldInput->first);
+                    return true; 
+                }
+                //Key is used
+                if(inputMapping.count(e.key.keysym.sym) == 1)
+                    return false;
+            }
+        }
+    }
+}

--- a/lib/input/input.cpp
+++ b/lib/input/input.cpp
@@ -1,21 +1,29 @@
 #include "brickengine/input/input.hpp"
+#include "brickengine/input/player_input.hpp"
 #include "SDL2/SDL.h"
 
-BrickInput::BrickInput() {
-
-}
+BrickInput& BrickInput::getInstance() {
+    static BrickInput INSTANCE;
+    return INSTANCE;
+};
 
 void BrickInput::processInput(){
     SDL_Event e;
-    while(SDL_PollEvent(&e) != 0 )
+    while (SDL_PollEvent(&e))
     {
-        if(e.type == SDL_KEYDOWN)
-        {
-            std::cout << "Key pressed!!!" << std::endl;
+        // Checking if input is mapped.
+        if(inputMapping.find(e.key.keysym.sym) != inputMapping.end()) {
+            if (e.type == SDL_KEYDOWN)
+                inputs[inputMapping[e.key.keysym.sym]] = true;
+            else
+                inputs[inputMapping[e.key.keysym.sym]] = false;
         }
     }
-}
+};
 
-void BrickInput::setInputMapping(std::unordered_map<std::string, std::string>& gameInput) {
+void BrickInput::setInputMapping(std::unordered_map<SDL_Keycode, PlayerInput>& gameInput) {
     inputMapping = gameInput;
-}
+    for(auto it : inputMapping) {
+        inputs[it.second] = false;
+    }
+};

--- a/lib/input/input.cpp
+++ b/lib/input/input.cpp
@@ -26,11 +26,6 @@ void BrickInput::processInput(){
             
         }
     }
-    for(auto it : inputs) {
-        if(it.second) {
-            std::cout <<  it.first << std::endl;
-        }
-    }
 };
 
 void BrickInput::setInputMapping(std::unordered_map<SDL_Keycode, PlayerInput>& gameInput) {

--- a/lib/input/input.cpp
+++ b/lib/input/input.cpp
@@ -1,0 +1,21 @@
+#include "brickengine/input/input.hpp"
+#include "SDL2/SDL.h"
+
+BrickInput::BrickInput() {
+
+}
+
+void BrickInput::processInput(){
+    SDL_Event e;
+    while(SDL_PollEvent(&e) != 0 )
+    {
+        if(e.type == SDL_KEYDOWN)
+        {
+            std::cout << "Key pressed!!!" << std::endl;
+        }
+    }
+}
+
+void BrickInput::setInputMapping(std::unordered_map<std::string, std::string>& gameInput) {
+    inputMapping = gameInput;
+}


### PR DESCRIPTION
This PR adds the input system.

Some functions still need to be implemented wether they are needed or not. 
Not much code but a lot of headscratching with flagging inputs in a `unordered_map`.

If you want to test this then you should get an instance of BrickInput.
Create a list of input maps and set them using the setter.
```c++
int main(int argc, char** argv) {
    auto engine = BrickEngine();
    engine.Start("Beast Arena");
    auto input = BrickInput::getInstance();
    std::unordered_map<SDL_Keycode, PlayerInput> inputMapping;
    inputMapping[SDLK_w] = PlayerInput::PLAYER1_UP;
    inputMapping[SDLK_a] = PlayerInput::PLAYER1_LEFT;
    inputMapping[SDLK_s] = PlayerInput::PLAYER1_DOWN;
    inputMapping[SDLK_d] = PlayerInput::PLAYER1_RIGHT;
    input.setInputMapping(inputMapping);
    input.popInput(PlayerInput::PLAYER1_UP);
    engine.Shutdown();
    return 0;
}
```
Then you can call the functions for processInput and remapInput
You can add some cout's to check what has been inputted.

Valgrind detects some memory leaks but I did not see any that were related.
