### PR TITLE
Fixed having to create an instance of a generic type in entity_manager

### DIFF
--- a/include/brickengine/components/component.hpp
+++ b/include/brickengine/components/component.hpp
@@ -3,11 +3,12 @@
 
 #include <iostream>
 
-class Component{
+class Component {
 public:
     Component() = default;
     virtual ~Component() = default;
 
     virtual std::string getName() = 0;
 };
+
 #endif /* FILE_COMPONENT_HPP */

--- a/include/brickengine/components/component_impl.hpp
+++ b/include/brickengine/components/component_impl.hpp
@@ -1,0 +1,14 @@
+#ifndef FILE_COMPONENT_IMPL_HPP
+#define FILE_COMPONENT_IMPL_HPP
+#include <iostream>
+
+template<class ComponentType>
+class ComponentImpl : public Component
+{
+public:
+    virtual std::string getName()
+    {
+        return ComponentType::getNameStatic();
+    }
+};
+#endif /* FILE_COMPONENT_IMPL_HPP */

--- a/include/brickengine/components/health_component.hpp
+++ b/include/brickengine/components/health_component.hpp
@@ -1,14 +1,14 @@
 #ifndef FILE_HEALTH_COMPONENT_HPP
 #define FILE_HEALTH_COMPONENT_HPP
 
-#include "component.hpp"
+#include "brickengine/components/component_impl.hpp"
 
-class HealthComponent : public Component {
+class HealthComponent : public ComponentImpl<HealthComponent> {
 public:
     HealthComponent(int hp): hp(hp) { };
     HealthComponent(): hp(0) { };
     int hp;
-    std::string getName() {
+    static std::string getNameStatic() {
         return "HealthComponent";
     };
 };

--- a/include/brickengine/components/renderable_component.hpp
+++ b/include/brickengine/components/renderable_component.hpp
@@ -1,10 +1,12 @@
 #ifndef FILE_RENDERABLE_COMPONENT_HPP
 #define FILE_RENDERABLE_COMPONENT_HPP
 
-#include "component.hpp"
+#include "brickengine/components/component_impl.hpp"
 
-class RenderableComponent : public Component {
-
+class RenderableComponent : public ComponentImpl<RenderableComponent> {
+    static std::string getNameStatic() {
+        return "RenderableComponent";
+    }
 };
 
 #endif /* FILE_RENDERABLE_COMPONENT_HPP */

--- a/include/brickengine/entities/entity_manager.hpp
+++ b/include/brickengine/entities/entity_manager.hpp
@@ -2,6 +2,7 @@
 #define FILE_ENTITY_MANAGER_HPP
 
 #include "brickengine/components/component.hpp"
+#include "brickengine/components/component_impl.hpp"
 #include "brickengine/entities/entity_with_component.hpp"
 
 #include <iostream>
@@ -30,8 +31,7 @@ public:
 
     template <typename T, typename = std::enable_if_t<std::is_base_of_v<Component, T>>>
     std::unique_ptr<std::vector<std::unique_ptr<EntityWithComponent<T>>>> getEntitiesByComponent(){
-        auto c = std::unique_ptr<Component>(new T());
-        std::string componentType = c->getName();
+        std::string componentType = T::getNameStatic();
         auto list = std::unique_ptr<std::vector<std::unique_ptr<EntityWithComponent<T>>>>(new std::vector<std::unique_ptr<EntityWithComponent<T>>>(components_by_class->at(componentType).size()));
         list.get()->clear();
         if(components_by_class->count(componentType) > 0){
@@ -45,16 +45,14 @@ public:
 
     template <typename T, typename = std::enable_if_t<std::is_base_of_v<Component, T>>>
     void removeComponentFromEntity(const int entityId){
-        auto c = std::unique_ptr<Component>(new T());
-        std::string componentType = c->getName();
+        std::string componentType = T::getNameStatic();
 
         components_by_class->at(componentType).erase(entityId);
     }
 
     template <typename T, typename = std::enable_if_t<std::is_base_of_v<Component, T>>>
     T* getComponent(const int entityId) const {
-        auto c = std::unique_ptr<Component>(new T());
-        std::string componentType { c->getName() };
+        std::string componentType = T::getNameStatic();
         if(components_by_class->count(componentType) > 0)
             return (T*) components_by_class->at(componentType).at(entityId).get();
         else


### PR DESCRIPTION
When creating a component such as `VelocityComponent`, you will now have to inherit from `ComponentImpl`.
The idea came from [this stackoverflow post](https://stackoverflow.com/a/28524588).