### PR TITLE
Fixed sanitizer not working, also added it to the test bin

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,14 +15,21 @@ jobs:
     - uses: actions/checkout@v1
     - name: Clone submodules
       run: git submodule update --init --recursive
-    - name: Update
+    - name: Add CMake PPA to get a reasonably updated version of CMake
+      run: |
+        wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | sudo apt-key add -
+        sudo apt-add-repository 'deb https://apt.kitware.com/ubuntu/ bionic main'
+    - name: Update the local repositories
       run: sudo apt-get update
+    - name: Update CMake
+      run: |
+        sudo apt-get install cmake
     - name: Install SDL dependencies
       run: sudo apt-get install libsdl2-dev libsdl2-gfx-dev libsdl2-image-dev libsdl2-mixer-dev libsdl2-net-dev libsdl2-ttf-dev
     - name: Build
       run: |
         cd build
-        cmake ..
+        /usr/bin/cmake ..
         make
     - name: C++ check
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,17 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.13.5)
 
 project(BrickEngine)
 include(CMakePrintHelpers)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Force colors when using ninja with clang
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    add_compile_options(-fcolor-diagnostics)
+elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    add_compile_options(-fdiagnostics-color=always)
+endif()
+
+# Add custom cmake modules
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/sdl2)
 
 add_subdirectory(include/brickengine)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,20 +1,5 @@
 file(GLOB_RECURSE BRICKENGINE_SRC_FILES RELATIVE ${CMAKE_CURRENT_LIST_DIR} *.c[p]*)
 
-## Compiler options
-# Make the compiler complain, a lot
-# Force colors when using ninja with clang
-if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-fcolor-diagnostics)
-elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    add_compile_options(-fdiagnostics-color=always)
-endif()
-# Turn on the address sanitizer for safety checks
-option(BRICKENGINE_SANITIZER "Turn on the address sanitizer" OFF)
-if(BRICKENGINE_SANITIZER)
-    add_compile_options(-fsanitize=address -fno-omit-frame-pointer)
-    add_link_options(-fsanitize=address)
-endif()
-add_compile_options(-Wall -Wextra -pedantic -Werror)
 
 find_package(SDL2 REQUIRED)
 find_package(SDL2_net REQUIRED)
@@ -25,6 +10,9 @@ find_package(SDL2_image REQUIRED)
 add_library(BrickEngine STATIC
     ${BRICKENGINE_SRC_FILES}
 )
+# Make the compiler complain, a lot
+target_compile_options(BrickEngine
+    PRIVATE -Wall -Wextra -pedantic -Werror)
 target_include_directories(BrickEngine PUBLIC ../include)
 target_link_libraries(BrickEngine
     PRIVATE SDL2::Main

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,17 @@ add_subdirectory("../extern/googletest" "extern/googletest")
 file(GLOB_RECURSE TEST_FILES RELATIVE ${CMAKE_CURRENT_LIST_DIR} *.c[p]*)
 
 add_executable(BrickEngine_Test ${TEST_FILES})
+# Make the compiler complain, a lot
+target_compile_options(BrickEngine_Test
+    PRIVATE -Wall -Wextra -pedantic -Werror)
+# Turn on the address sanitizer for safety checks
+option(BRICKENGINE_TEST_SANITIZER "Turn on the address sanitizer" OFF)
+if(BRICKENGINE_TEST_SANITIZER)
+    target_compile_options(BrickEngine_Test
+        PRIVATE -fsanitize=address -fno-omit-frame-pointer)
+    target_link_options(BrickEngine_Test
+        PRIVATE -fsanitize=address)
+endif()
 target_link_libraries(BrickEngine_Test PRIVATE
     BrickEngine
     gtest


### PR DESCRIPTION
# Description

The sanitizer wasn't working with the new test framework. This PR fixes the sanitizer, adds the sanitizer the test binary and adds errors and warnings compiler flags to the test binary. The same fix and changes have been applied to the game in [this PR](https://github.com/Brick-Studios/BeastArena/pull/19).

I also updated CMake on Github Actions so that it supports the newer and better commands.

# How can this be tested?

Build the project with and without tests, with and without the sanitizer.

# What I found out during this PR
- The address sanitizer should only be linked to the final binary. See [this source](https://clang.llvm.org/docs/AddressSanitizer.html).
- When adding compiler and linker options, you should use _target_link_options_ and _target_compile_options_ to only add those options to a specific target instead of leaving it to CMake to choose which targets get those options.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Included 1 or more screenshots
- [x] Code is const correct