### PR TITLE
Fixed building the engine on master

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
         /usr/bin/cmake ..
         make
     - name: Build master
-      if: github.ref == 'master'
+      if: github.ref == 'refs/heads/master'
       run: |
         export CXX=clang++
         cd build


### PR DESCRIPTION
# Description

Apparently the correct syntax for github.ref = 'refs/heads/master'
