### PR TITLE
Fixed movement and deltatime

### DIFF
--- a/include/brickengine/systems/physics_system.hpp
+++ b/include/brickengine/systems/physics_system.hpp
@@ -11,7 +11,7 @@ public:
     PhysicsSystem(std::shared_ptr<CollisionDetector> cd, std::shared_ptr<EntityManager> em);
     void update(double deltatime);
 private:
-    static constexpr double GRAVITY = 25;
+    static constexpr double GRAVITY = 100;
     static constexpr double TERMINAL_VELOCITY = 1000;
 
     std::shared_ptr<CollisionDetector> collisionDetector;

--- a/include/brickengine/systems/physics_system.hpp
+++ b/include/brickengine/systems/physics_system.hpp
@@ -11,7 +11,7 @@ public:
     PhysicsSystem(std::shared_ptr<CollisionDetector> cd, std::shared_ptr<EntityManager> em);
     void update(double deltatime);
 private:
-    static constexpr double GRAVITY = 100;
+    static constexpr double GRAVITY = 10;
     static constexpr double TERMINAL_VELOCITY = 1000;
 
     std::shared_ptr<CollisionDetector> collisionDetector;

--- a/include/brickengine/systems/physics_system.hpp
+++ b/include/brickengine/systems/physics_system.hpp
@@ -11,7 +11,7 @@ public:
     PhysicsSystem(std::shared_ptr<CollisionDetector> cd, std::shared_ptr<EntityManager> em);
     void update(double deltatime);
 private:
-    static constexpr double GRAVITY = 10;
+    static constexpr double GRAVITY = 0.1;
     static constexpr double TERMINAL_VELOCITY = 1000;
 
     std::shared_ptr<CollisionDetector> collisionDetector;

--- a/lib/engine.cpp
+++ b/lib/engine.cpp
@@ -1,4 +1,3 @@
-
 #include <iostream>
 #include <string>
 #include <memory>
@@ -81,16 +80,31 @@ void BrickEngine::stop() {
 
 void BrickEngine::delay(std::chrono::time_point<std::chrono::high_resolution_clock> start_time,
                           std::chrono::time_point<std::chrono::high_resolution_clock> end_time) {
-    auto delta_time_in_nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(end_time - start_time).count();
-    this->delta_time = delta_time_in_nanoseconds / 1'000'000'000.0;
-    double fps_frame_time = 1.0 / fps_cap;
-    auto delay = 0.0;
-    if(delta_time < fps_frame_time) {
-        delay = (fps_frame_time - delta_time);
-        SDL_Delay(delay);
-    }
+    typedef std::chrono::nanoseconds nanoseconds;
+    typedef std::chrono::duration<double> seconds;
 
-    this->fps = 1.0 / (delta_time + delay);
+    nanoseconds delta_time_in_nanoseconds = std::chrono::duration_cast<nanoseconds>(end_time - start_time);;
+    //this->delta_time = delta_time_in_nanoseconds / 1'000'000'000.0;
+
+    nanoseconds fps_frame_time { (1'000'000'000 / fps_cap)};
+    //auto fps_frame_time = std::chrono::duration<double, std::chrono::nanoseconds>(std::chrono::seconds(1) / fps_cap);
+    nanoseconds delay { 0 };
+    if(delta_time_in_nanoseconds < fps_frame_time) {
+        delay = (fps_frame_time - delta_time_in_nanoseconds);
+        //int d = delay * 1000;
+        std::this_thread::sleep_for(delay);
+    }
+    this->delta_time = std::chrono::duration_cast<seconds>(delta_time_in_nanoseconds + delay).count();
+    //this->delta_time = std::chrono::duration<double>(std::chrono::duration_cast<std::chrono::seconds>(delta_time_in_nanoseconds + delay)).count();
+    std::cout << "FPSFRAMETIME: " << fps_frame_time.count()  << std::endl;
+    std::cout << "Delta: " << delta_time_in_nanoseconds.count()  << std::endl;
+    std::cout << "Delta + delay: " << delta_time << std::endl;
+    std::cout << "Delay: " << delay.count() << std::endl;
+    std::cout << "FPS: " << (1.0 / delta_time) << std::endl;
+    this->fps = 1.0 / delta_time;
+    //this->delta_time = std::chrono::duration_cast<std::chrono::seconds>(delta_time_in_nanoseconds) + std::chrono::duration_cast<std::chrono::seconds>(delay);
+    //this->delta_time += delay;
+    //this->fps = 1.0 / delta_time + delay;
 }
 
 void BrickEngine::drawFpsCounter() {

--- a/lib/engine.cpp
+++ b/lib/engine.cpp
@@ -14,7 +14,7 @@
 #include "SDL2/SDL_image.h"
 
 BrickEngine::BrickEngine(const std::string window_name, const int window_width, const int window_height, std::vector<int> layers, int fps_cap) : fps_cap(fps_cap), window(nullptr, nullptr) {
-    this->fps = 0;
+    this->fps = 5;
     this->layers = layers;
     this->top_layer = layers.back();
     this->window_name = window_name;
@@ -80,31 +80,19 @@ void BrickEngine::stop() {
 
 void BrickEngine::delay(std::chrono::time_point<std::chrono::high_resolution_clock> start_time,
                           std::chrono::time_point<std::chrono::high_resolution_clock> end_time) {
-    typedef std::chrono::nanoseconds nanoseconds;
-    typedef std::chrono::duration<double> seconds;
+    using nanoseconds = std::chrono::nanoseconds;
+    using seconds = std::chrono::duration<double>;
 
-    nanoseconds delta_time_in_nanoseconds = std::chrono::duration_cast<nanoseconds>(end_time - start_time);;
-    //this->delta_time = delta_time_in_nanoseconds / 1'000'000'000.0;
+    nanoseconds delta_time_in_nanoseconds = std::chrono::duration_cast<nanoseconds>(end_time - start_time);
 
     nanoseconds fps_frame_time { (1'000'000'000 / fps_cap)};
-    //auto fps_frame_time = std::chrono::duration<double, std::chrono::nanoseconds>(std::chrono::seconds(1) / fps_cap);
     nanoseconds delay { 0 };
     if(delta_time_in_nanoseconds < fps_frame_time) {
         delay = (fps_frame_time - delta_time_in_nanoseconds);
-        //int d = delay * 1000;
         std::this_thread::sleep_for(delay);
     }
     this->delta_time = std::chrono::duration_cast<seconds>(delta_time_in_nanoseconds + delay).count();
-    //this->delta_time = std::chrono::duration<double>(std::chrono::duration_cast<std::chrono::seconds>(delta_time_in_nanoseconds + delay)).count();
-    std::cout << "FPSFRAMETIME: " << fps_frame_time.count()  << std::endl;
-    std::cout << "Delta: " << delta_time_in_nanoseconds.count()  << std::endl;
-    std::cout << "Delta + delay: " << delta_time << std::endl;
-    std::cout << "Delay: " << delay.count() << std::endl;
-    std::cout << "FPS: " << (1.0 / delta_time) << std::endl;
     this->fps = 1.0 / delta_time;
-    //this->delta_time = std::chrono::duration_cast<std::chrono::seconds>(delta_time_in_nanoseconds) + std::chrono::duration_cast<std::chrono::seconds>(delay);
-    //this->delta_time += delay;
-    //this->fps = 1.0 / delta_time + delay;
 }
 
 void BrickEngine::drawFpsCounter() {

--- a/lib/systems/physics_system.cpp
+++ b/lib/systems/physics_system.cpp
@@ -21,49 +21,47 @@ void PhysicsSystem::update(double deltatime) {
 
         if (physics->gravity) {
             // Also do collisions
-            double vy = physics->vy + (GRAVITY * mass * deltatime);
+            double vy = physics->vy + (GRAVITY * mass);
 
             if (vy > TERMINAL_VELOCITY)
                 vy = TERMINAL_VELOCITY;
-
+            
             physics->vy = vy;
         }
 
+        double vx = physics->vx * deltatime;
+        double vy = physics->vy * deltatime;
         if (physics->vx > 0) { // Moving right
             double spaceLeft = collisionDetector->spaceLeft(entityId, Axis::X, Direction::POSITIVE);
-            double wantToMove  = physics->vx * deltatime;
+            double wantToMove = vx;
+            double toMove = (wantToMove >= spaceLeft) ? spaceLeft : wantToMove;
+            std::cout << "TO MOVE RIGHT: " << toMove << std::endl;
 
-            if (wantToMove >= spaceLeft)
-                transform->xPos = transform->xPos + spaceLeft;
-            else if (wantToMove < spaceLeft)
-                transform->xPos = transform->xPos + wantToMove;
+            transform->xPos = transform->xPos + toMove;
         }
         if (physics->vx < 0) { // Moving left
             double spaceLeft = collisionDetector->spaceLeft(entityId, Axis::X, Direction::NEGATIVE);
-            double wantToMove = physics->vx * deltatime;
+            double wantToMove = vx;
+            double toMove = (wantToMove <= spaceLeft) ? spaceLeft : wantToMove;
+            std::cout << "TO MOVE LEFT: " << toMove << std::endl;
 
-            if (wantToMove <= spaceLeft) {
-                transform->xPos = transform->xPos + spaceLeft;
-            } else if (wantToMove > spaceLeft)
-                transform->xPos = transform->xPos + wantToMove;
+            transform->xPos = transform->xPos + toMove;
         }
         if (physics->vy > 0) { // Moving down
             double spaceLeft = collisionDetector->spaceLeft(entityId, Axis::Y, Direction::POSITIVE);
-            double wantToMove = physics->vy * deltatime;
+            double wantToMove = vy;
+            double toMove = (wantToMove >= spaceLeft) ? spaceLeft : wantToMove;
+            std::cout << "TO MOVE DOWN: " << toMove << std::endl;
 
-            if (wantToMove >= spaceLeft)
-                transform->yPos = transform->yPos + spaceLeft;
-            else if (wantToMove < spaceLeft)
-                transform->yPos = transform->yPos + wantToMove;
+            transform->yPos = transform->yPos + toMove;
         }
         if (physics->vy < 0) { // Moving up
             double spaceLeft = collisionDetector->spaceLeft(entityId, Axis::Y, Direction::NEGATIVE);
-            double wantToMove = physics->vy * deltatime;
+            double wantToMove = vy;
+            double toMove = (wantToMove <= spaceLeft) ? spaceLeft : wantToMove;
+            std::cout << "TO MOVE UP: " << toMove << std::endl;
 
-            if (wantToMove <= spaceLeft)
-                transform->yPos = transform->yPos + spaceLeft;
-            else if (wantToMove > spaceLeft)
-                transform->yPos = transform->yPos + wantToMove;
+            transform->yPos = transform->yPos + toMove;
         }
     }
 }

--- a/lib/systems/physics_system.cpp
+++ b/lib/systems/physics_system.cpp
@@ -21,7 +21,7 @@ void PhysicsSystem::update(double deltatime) {
 
         if (physics->gravity) {
             // Also do collisions
-            double vy = physics->vy + (GRAVITY * mass);
+            double vy = physics->vy + (GRAVITY * mass) * deltatime;
 
             if (vy > TERMINAL_VELOCITY)
                 vy = TERMINAL_VELOCITY;
@@ -35,7 +35,6 @@ void PhysicsSystem::update(double deltatime) {
             double spaceLeft = collisionDetector->spaceLeft(entityId, Axis::X, Direction::POSITIVE);
             double wantToMove = vx;
             double toMove = (wantToMove >= spaceLeft) ? spaceLeft : wantToMove;
-            std::cout << "TO MOVE RIGHT: " << toMove << std::endl;
 
             transform->xPos = transform->xPos + toMove;
         }
@@ -43,7 +42,6 @@ void PhysicsSystem::update(double deltatime) {
             double spaceLeft = collisionDetector->spaceLeft(entityId, Axis::X, Direction::NEGATIVE);
             double wantToMove = vx;
             double toMove = (wantToMove <= spaceLeft) ? spaceLeft : wantToMove;
-            std::cout << "TO MOVE LEFT: " << toMove << std::endl;
 
             transform->xPos = transform->xPos + toMove;
         }
@@ -51,7 +49,6 @@ void PhysicsSystem::update(double deltatime) {
             double spaceLeft = collisionDetector->spaceLeft(entityId, Axis::Y, Direction::POSITIVE);
             double wantToMove = vy;
             double toMove = (wantToMove >= spaceLeft) ? spaceLeft : wantToMove;
-            std::cout << "TO MOVE DOWN: " << toMove << std::endl;
 
             transform->yPos = transform->yPos + toMove;
         }
@@ -59,7 +56,6 @@ void PhysicsSystem::update(double deltatime) {
             double spaceLeft = collisionDetector->spaceLeft(entityId, Axis::Y, Direction::NEGATIVE);
             double wantToMove = vy;
             double toMove = (wantToMove <= spaceLeft) ? spaceLeft : wantToMove;
-            std::cout << "TO MOVE UP: " << toMove << std::endl;
 
             transform->yPos = transform->yPos + toMove;
         }

--- a/lib/systems/physics_system.cpp
+++ b/lib/systems/physics_system.cpp
@@ -21,7 +21,7 @@ void PhysicsSystem::update(double deltatime) {
 
         if (physics->gravity) {
             // Also do collisions
-            double vy = physics->vy + (GRAVITY * mass) * deltatime;
+            double vy = physics->vy + (GRAVITY * mass);
 
             if (vy > TERMINAL_VELOCITY)
                 vy = TERMINAL_VELOCITY;

--- a/lib/systems/physics_system.cpp
+++ b/lib/systems/physics_system.cpp
@@ -26,7 +26,7 @@ void PhysicsSystem::update(double deltatime) {
             if (vy > TERMINAL_VELOCITY)
                 vy = TERMINAL_VELOCITY;
 
-            physics->vy = vy;
+            //physics->vy = vy;
         }
 
         if (physics->vx > 0) { // Moving right
@@ -65,5 +65,7 @@ void PhysicsSystem::update(double deltatime) {
             else if (wantToMove > spaceLeft)
                 transform->yPos = transform->yPos + wantToMove;
         }
+        std::cout << physics->vy * deltatime << std::endl;
+        std::cout << physics->vx * deltatime << std::endl;
     }
 }

--- a/lib/systems/physics_system.cpp
+++ b/lib/systems/physics_system.cpp
@@ -26,7 +26,7 @@ void PhysicsSystem::update(double deltatime) {
             if (vy > TERMINAL_VELOCITY)
                 vy = TERMINAL_VELOCITY;
 
-            //physics->vy = vy;
+            physics->vy = vy;
         }
 
         if (physics->vx > 0) { // Moving right
@@ -65,7 +65,5 @@ void PhysicsSystem::update(double deltatime) {
             else if (wantToMove > spaceLeft)
                 transform->yPos = transform->yPos + wantToMove;
         }
-        std::cout << physics->vy * deltatime << std::endl;
-        std::cout << physics->vx * deltatime << std::endl;
     }
 }


### PR DESCRIPTION
# Description

We might have finally got around to fixing deltatime.....
We rewrote the deltatime/fps calculating part of the engine to use as much chrono variables as possible(to minimize the amount of mistakes) and added the delay time to the deltatime. Yes you are reading this right, the thing we thought we were doing wrong, well we are doing that again. But this time it works!

The second part of this fix consists of how we actually use that deltatime(including the delay time and in seconds) in our systems. What we found is that you should multiply values like velocity by deltatime at very specific times during the calculations, only when actually applying the values should you multiply the value by deltatime. So for movement this would entail not applying deltatime in the MovementSystem, but setting the velocity to it's per second value and then in the PhysicsSystem when applying the velocity we multiply it by deltatime to get the velocity per frame. This is to prevent multiplying by deltatime multiple times, which would change the value by way to much as it accentuates the effect of deltatime.

# How can this be tested?

- Try this code with [this BeastArena PR](https://github.com/Brick-Studios/BeastArena/pull/25) on as many PC's and performance profiles as you can and compare the game speed.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Included 1 or more screenshots
- [x] Code is const correct
