### PR TITLE
Fixed bug where velocity wouldn't be reset by physics when collision occurs

### DIFF
--- a/include/brickengine/systems/physics_system.hpp
+++ b/include/brickengine/systems/physics_system.hpp
@@ -11,7 +11,7 @@ public:
     PhysicsSystem(std::shared_ptr<CollisionDetector> cd, std::shared_ptr<EntityManager> em);
     void update(double deltatime);
 private:
-    static constexpr double GRAVITY = 0.1;
+    static constexpr double GRAVITY = 0.16;
     static constexpr double TERMINAL_VELOCITY = 1000;
 
     std::shared_ptr<CollisionDetector> collisionDetector;

--- a/lib/systems/physics_system.cpp
+++ b/lib/systems/physics_system.cpp
@@ -33,6 +33,10 @@ void PhysicsSystem::update(double deltatime) {
         double vy = physics->vy * deltatime;
         if (physics->vx > 0) { // Moving right
             double spaceLeft = collisionDetector->spaceLeft(entityId, Axis::X, Direction::POSITIVE);
+            if (spaceLeft == 0) {
+                physics->vx = 0;
+            }
+
             double wantToMove = vx;
             double toMove = (wantToMove >= spaceLeft) ? spaceLeft : wantToMove;
 
@@ -40,6 +44,10 @@ void PhysicsSystem::update(double deltatime) {
         }
         if (physics->vx < 0) { // Moving left
             double spaceLeft = collisionDetector->spaceLeft(entityId, Axis::X, Direction::NEGATIVE);
+            if (spaceLeft == 0) {
+                physics->vx = 0;
+            }
+
             double wantToMove = vx;
             double toMove = (wantToMove <= spaceLeft) ? spaceLeft : wantToMove;
 
@@ -47,6 +55,9 @@ void PhysicsSystem::update(double deltatime) {
         }
         if (physics->vy > 0) { // Moving down
             double spaceLeft = collisionDetector->spaceLeft(entityId, Axis::Y, Direction::POSITIVE);
+            if (spaceLeft == 0) {
+                physics->vy = 0;
+            }
             double wantToMove = vy;
             double toMove = (wantToMove >= spaceLeft) ? spaceLeft : wantToMove;
 
@@ -54,6 +65,10 @@ void PhysicsSystem::update(double deltatime) {
         }
         if (physics->vy < 0) { // Moving up
             double spaceLeft = collisionDetector->spaceLeft(entityId, Axis::Y, Direction::NEGATIVE);
+            if (spaceLeft == 0) {
+                physics->vy = 0;
+            }
+
             double wantToMove = vy;
             double toMove = (wantToMove <= spaceLeft) ? spaceLeft : wantToMove;
 


### PR DESCRIPTION
# Description

This PR fixes a bug where the velocity of an entity would not be reset after it collided with something in the physics system. It also tweaks the gravity slightly

# How can this be tested?
By running the game and testing 'how' the gravity is. 

*Test it with [this PR](https://github.com/Brick-Studios/BeastArena/pull/26)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Included 1 or more screenshots
- [x] Code is const correct
