### PR TITLE
Collision caching, ECS tagging, component cloning and deltatime fix

### DIFF
--- a/include/brickengine/collision_detector.hpp
+++ b/include/brickengine/collision_detector.hpp
@@ -55,12 +55,19 @@ struct TriggerReturnValues {
 
 class CollisionDetector {
 public:
-		CollisionDetector(std::shared_ptr<EntityManager> em);
-		// Returns amount of pixels that can still be moved to the collidable object.
-		CollisionReturnValues spaceLeft(int entity, Axis axis, Direction direction);
+    CollisionDetector(std::shared_ptr<EntityManager> em);
+    // Returns amount of pixels that can still be moved to the collidable object.
+    CollisionReturnValues spaceLeft(int entity, Axis axis, Direction direction);
     TriggerReturnValues isInTrigger(int entity);
+    void clearCache();
+    int space_left_calculated_counter;
+    int trigger_calculated_counter;
+    int space_left_cache_hits;
+    int trigger_cache_hits;
 private:
-		std::shared_ptr<EntityManager> entity_manager;
+    std::shared_ptr<EntityManager> entity_manager;
+    std::unordered_map<int, std::unordered_map<Axis, std::unordered_map<Direction, CollisionReturnValues>>> space_left_cache;
+    std::unordered_map<int, TriggerReturnValues> trigger_cache;
 };
 
 #endif // FILE_COLLISION_DETECTOR_HPP

--- a/include/brickengine/components/colliders/rectangle_collider_component.hpp
+++ b/include/brickengine/components/colliders/rectangle_collider_component.hpp
@@ -5,14 +5,14 @@
 
 class RectangleColliderComponent : public ComponentImpl<RectangleColliderComponent> {
 public:
-    RectangleColliderComponent(double xScale, double yScale, double zScale, bool isTrigger);
+    RectangleColliderComponent(double x_scale, double y_scale, double z_scale, bool is_trigger);
     static std::string getNameStatic();
 
     // Data
-    double xScale;
-    double yScale;
-    double zScale;
-    bool isTrigger; // If the component is able to be moved through and only be used as a "trigger"
+    double x_scale;
+    double y_scale;
+    double z_scale;
+    bool is_trigger; // If the component is able to be moved through and only be used as a "trigger"
 };
 
 #endif // FILE_RECTANGLE_COLLISION_COMPONENT_HPP

--- a/include/brickengine/components/player_component.hpp
+++ b/include/brickengine/components/player_component.hpp
@@ -5,11 +5,12 @@
 
 class PlayerComponent : public ComponentImpl<PlayerComponent> {
 public:
-    PlayerComponent(int playerId);
+    PlayerComponent(int player_id, bool disabled = false);
     static std::string getNameStatic();
 
     // Data
-    int playerId;
+    int player_id;
+    bool disabled;
 };
 
 #endif // FILE_PLAYER_COMPONENT_HPP

--- a/include/brickengine/components/renderables/texture_component.hpp
+++ b/include/brickengine/components/renderables/texture_component.hpp
@@ -9,6 +9,12 @@
 class TextureComponent : public ComponentImpl<TextureComponent>{
 public:
     TextureComponent(std::unique_ptr<Texture> t);
+    TextureComponent(const TextureComponent& other);
+    TextureComponent(TextureComponent&& other) noexcept = default;
+    TextureComponent& operator=(TextureComponent&& other) = default;
+    TextureComponent& operator=(const TextureComponent& other);
+    // This can stay default because we don't own any pointers here
+    ~TextureComponent() = default;
     static std::string getNameStatic();
 
     Texture* getTexture() const;

--- a/include/brickengine/components/transform_component.hpp
+++ b/include/brickengine/components/transform_component.hpp
@@ -6,16 +6,16 @@
 
 class TransformComponent : public ComponentImpl<TransformComponent> {
 public:
-    TransformComponent(double xPos, double yPos, double xScale, double yScale, Direction xDirection, Direction yDirection);
+    TransformComponent(double x_pos, double y_pos, double x_scale, double y_scale, Direction x_direction, Direction y_direction);
     static std::string getNameStatic();
 
     // Data
-    double xPos;
-    double yPos;
-    double xScale;
-    double yScale;
-    Direction xDirection;
-    Direction yDirection;
+    double x_pos;
+    double y_pos;
+    double x_scale;
+    double y_scale;
+    Direction x_direction;
+    Direction y_direction;
 };
 
 #endif // FILE_TRANSFORM_HPP

--- a/include/brickengine/entities/entity_manager.hpp
+++ b/include/brickengine/entities/entity_manager.hpp
@@ -137,10 +137,10 @@ public:
 
         if (!transform_is_relative) {
             auto [ parent_absolute_position, parent_absolute_scale ] = getAbsoluteTransform(parent_id);
-            child_transform->xPos -= parent_absolute_position.x;
-            child_transform->yPos -= parent_absolute_position.y;
-            child_transform->xScale /= parent_absolute_scale.x;
-            child_transform->yScale /= parent_absolute_scale.y;
+            child_transform->x_pos -= parent_absolute_position.x;
+            child_transform->y_pos -= parent_absolute_position.y;
+            child_transform->x_scale /= parent_absolute_scale.x;
+            child_transform->y_scale /= parent_absolute_scale.y;
         }
         
         if (child_physics && child_physics->kinematic == Kinematic::IS_NOT_KINEMATIC)
@@ -181,10 +181,10 @@ public:
         auto old_parent_transform = getComponent<TransformComponent>(old_parent);
 
         auto child_transform = getComponent<TransformComponent>(entity_id);
-        child_transform->xPos += old_parent_transform->xPos;
-        child_transform->yPos += old_parent_transform->yPos;
-        child_transform->xScale *= old_parent_transform->xScale;
-        child_transform->yScale *= old_parent_transform->yScale;
+        child_transform->x_pos += old_parent_transform->x_pos;
+        child_transform->y_pos += old_parent_transform->y_pos;
+        child_transform->x_scale *= old_parent_transform->x_scale;
+        child_transform->y_scale *= old_parent_transform->y_scale;
 
         auto physics = getComponent<PhysicsComponent>(entity_id);
         if (physics && physics->kinematic == Kinematic::WAS_NOT_KINEMATIC)
@@ -196,8 +196,8 @@ public:
 
     std::pair<Position, Scale> getAbsoluteTransform(int id){
         auto transform = getComponent<TransformComponent>(id);
-        auto position = Position(transform->xPos, transform->yPos);
-        auto scale = Scale(transform->xScale, transform->yScale);
+        auto position = Position(transform->x_pos, transform->y_pos);
+        auto scale = Scale(transform->x_scale, transform->y_scale);
         if (auto parent = getParent(id)) {
             auto [ parent_position, parent_scale ] = getAbsoluteTransform(*parent);
 

--- a/include/brickengine/entities/entity_manager.hpp
+++ b/include/brickengine/entities/entity_manager.hpp
@@ -78,11 +78,11 @@ public:
     std::vector<std::pair<int, T*>> getChildrenWithComponent(const int parent_id) const {
         std::vector<std::pair<int, T*>> results;
 
-        if (!family_hierarcy_children.count(parent_id))
+        if (!family_hierarchy_children.count(parent_id))
             return results;
 
         std::string component_type = T::getNameStatic();
-        for (auto child_id : family_hierarcy_children.at(parent_id)) {
+        for (auto child_id : family_hierarchy_children.at(parent_id)) {
             if (components_by_class->count(component_type)) {
                 if (components_by_class->at(component_type).count(child_id))
                     results.push_back(std::make_pair(
@@ -108,10 +108,10 @@ public:
         if (!children.empty()) {
             // Forget that you have children
             for (auto& child_id : children) {
-                family_hierarcy_parents.erase(child_id);
+                family_hierarchy_parents.erase(child_id);
             }
             // Disown children
-            family_hierarcy_children.erase(entity_id);
+            family_hierarchy_children.erase(entity_id);
         }
 
         // Move out of a parents house(if it has one)
@@ -147,38 +147,38 @@ public:
         if (child_physics && child_physics->kinematic == Kinematic::IS_NOT_KINEMATIC)
             child_physics->kinematic = Kinematic::WAS_NOT_KINEMATIC;
 
-        if (family_hierarcy_parents.count(child_id)) {
-            int oldParent { family_hierarcy_parents[child_id] };
-            family_hierarcy_children[oldParent].erase(child_id);
+        if (family_hierarchy_parents.count(child_id)) {
+            int oldParent { family_hierarchy_parents[child_id] };
+            family_hierarchy_children[oldParent].erase(child_id);
         }
 
-        family_hierarcy_parents.insert_or_assign(child_id, parent_id);
-        if (!family_hierarcy_children.count(parent_id)) {
-            family_hierarcy_children[parent_id].insert(child_id);
+        family_hierarchy_parents.insert_or_assign(child_id, parent_id);
+        if (!family_hierarchy_children.count(parent_id)) {
+            family_hierarchy_children[parent_id].insert(child_id);
         }
         else {
-            family_hierarcy_children.insert({parent_id, std::set<int>()});
-            family_hierarcy_children[parent_id].insert(child_id);
+            family_hierarchy_children.insert({parent_id, std::set<int>()});
+            family_hierarchy_children[parent_id].insert(child_id);
         }
     }
 
     std::optional<int> getParent(int id) {
-        if (!family_hierarcy_parents.count(id))
+        if (!family_hierarchy_parents.count(id))
             return std::nullopt;
         else
-            return family_hierarcy_parents[id];
+            return family_hierarchy_parents[id];
     }
 
     std::set<int> getChildren(int id) {
-        if (!family_hierarcy_children.count(id))
+        if (!family_hierarchy_children.count(id))
             return std::set<int>();
         else
-            return family_hierarcy_children[id];
+            return family_hierarchy_children[id];
     }
 
     void moveOutOfParentsHouse(int entity_id) {
-        if (!family_hierarcy_parents.count(entity_id)) return;
-        int old_parent { family_hierarcy_parents[entity_id] };
+        if (!family_hierarchy_parents.count(entity_id)) return;
+        int old_parent { family_hierarchy_parents[entity_id] };
         auto old_parent_transform = getComponent<TransformComponent>(old_parent);
 
         auto child_transform = getComponent<TransformComponent>(entity_id);
@@ -191,8 +191,8 @@ public:
         if (physics && physics->kinematic == Kinematic::WAS_NOT_KINEMATIC)
             physics->kinematic = Kinematic::IS_NOT_KINEMATIC;
 
-        family_hierarcy_children[old_parent].erase(entity_id);
-        family_hierarcy_parents.erase(entity_id);
+        family_hierarchy_children[old_parent].erase(entity_id);
+        family_hierarchy_parents.erase(entity_id);
     }
 
     std::pair<Position, Scale> getAbsoluteTransform(int id){
@@ -239,8 +239,8 @@ private:
     int lowest_unassigned_entity_id;
     std::unique_ptr<std::unordered_map<std::string, std::unordered_map<int, std::unique_ptr<Component>>>> components_by_class;
     // Families, Parent-Child
-    std::unordered_map<int, int> family_hierarcy_parents;
-    std::unordered_map<int, std::set<int>> family_hierarcy_children;
+    std::unordered_map<int, int> family_hierarchy_parents;
+    std::unordered_map<int, std::set<int>> family_hierarchy_children;
     // Tagging, tags
     std::unordered_map<int, std::set<std::string>> tagging_entities;
     std::unordered_map<std::string, std::set<int>> tagging_tags;

--- a/include/brickengine/entities/entity_manager.hpp
+++ b/include/brickengine/entities/entity_manager.hpp
@@ -43,7 +43,7 @@ public:
     }
 
     template <typename T, typename = std::enable_if_t<std::is_base_of_v<Component, T>>>
-    std::unique_ptr<std::vector<std::pair<int, T*>>> getEntitiesByComponent(){
+    std::unique_ptr<std::vector<std::pair<int, T*>>> getEntitiesByComponent() {
         std::string component_type = T::getNameStatic();
         if (components_by_class->count(component_type) < 1)
             return std::make_unique<std::vector<std::pair<int, T*>>>();
@@ -197,11 +197,40 @@ public:
 
         return std::make_pair(position, scale);
     }
+
+    std::optional<std::set<std::string>> getTags(int entity) {
+        if (tagging_entities.count(entity))
+            return tagging_entities.at(entity);
+        else
+            return std::nullopt;
+    }
+    void setTag(int entity, std::string tag) {
+        if (!tagging_entities.count(entity))
+            tagging_entities.insert({ entity, std::set<std::string>() });
+        tagging_entities.at(entity).insert(tag);
+        if (!tagging_tags.count(tag))
+            tagging_tags.insert({ tag, std::set<int>() });
+        tagging_tags.at(tag).insert(entity);
+    }
+    void removeTag(int entity, std::string tag) {
+        if (!tagging_entities.count(entity)) return;
+        tagging_entities.erase(entity);
+        tagging_tags.erase(tag);
+    }
+    std::set<int> getEntitiesWithTag(std::string tag) {
+        if (!tagging_tags.count(tag))
+            return std::set<int>();
+        return tagging_tags.at(tag);
+    }
 private:
     int lowest_unassigned_entity_id;
     std::unique_ptr<std::unordered_map<std::string, std::unordered_map<int, std::unique_ptr<Component>>>> components_by_class;
+    // Families, Parent-Child
     std::unordered_map<int, int> family_hierarcy_parents;
     std::unordered_map<int, std::set<int>> family_hierarcy_children;
+    // Tagging, tags
+    std::unordered_map<int, std::set<std::string>> tagging_entities;
+    std::unordered_map<std::string, std::set<int>> tagging_tags;
 };
 
 #endif // FILE_ENTITY_MANAGER_HPP

--- a/include/brickengine/entities/entity_manager.hpp
+++ b/include/brickengine/entities/entity_manager.hpp
@@ -42,15 +42,15 @@ public:
     }
 
     template <typename T, typename = std::enable_if_t<std::is_base_of_v<Component, T>>>
-    std::unique_ptr<std::vector<std::pair<int, T*>>> getEntitiesByComponent() {
+    std::vector<std::pair<int, T*>> getEntitiesByComponent() {
         std::string component_type = T::getNameStatic();
         if (components_by_class.count(component_type) < 1)
-            return std::make_unique<std::vector<std::pair<int, T*>>>();
-        auto list = std::make_unique<std::vector<std::pair<int, T*>>>(components_by_class.at(component_type).size());
-        list->clear();
+            return std::vector<std::pair<int, T*>>();
+        std::vector<std::pair<int, T*>> list { components_by_class.at(component_type).size() };
+        list.clear();
         if(components_by_class.count(component_type) > 0){
             for(auto const& [entity_id, component] : components_by_class.at(component_type)){
-                list->push_back(std::make_pair(entity_id, dynamic_cast<T*>(component.get())));
+                list.push_back(std::make_pair(entity_id, dynamic_cast<T*>(component.get())));
             }
         }
         return list;

--- a/include/brickengine/entities/entity_manager.hpp
+++ b/include/brickengine/entities/entity_manager.hpp
@@ -103,17 +103,30 @@ public:
     }
 
     void removeEntity(const int entity_id) {
-        for(auto& component : *components_by_class)
-            component.second.erase(entity_id);
-        // If this entity has family
-        if (family_hierarcy_parents.count(entity_id)) {
+        auto children = getChildren(entity_id);
+        // If this entity has children
+        if (!children.empty()) {
             // Forget that you have children
-            for (auto child_id : family_hierarcy_children.at(entity_id)) {
+            for (auto& child_id : children) {
                 family_hierarcy_parents.erase(child_id);
             }
             // Disown children
             family_hierarcy_children.erase(entity_id);
         }
+
+        // Move out of a parents house(if it has one)
+        moveOutOfParentsHouse(entity_id);
+            
+        // if this entity has tags
+        if (tagging_entities.count(entity_id)) {
+            for (auto& tag : tagging_entities.at(entity_id)) {
+                tagging_tags.erase(tag);
+            }
+            tagging_entities.erase(entity_id);
+        }
+
+        for(auto& component : *components_by_class)
+            component.second.erase(entity_id);
     }
 
     void setParent(int child_id, int parent_id, bool transform_is_relative) {

--- a/include/brickengine/entities/exceptions/component_not_found.hpp
+++ b/include/brickengine/entities/exceptions/component_not_found.hpp
@@ -1,0 +1,18 @@
+#ifndef FILE_COMPONENT_NOT_FOUND_EXCEPTION_HPP
+#define FILE_COMPONENT_NOT_FOUND_EXCEPTION_HPP
+
+#include <iostream>
+#include <exception>
+
+class ComponentNotFoundException : public std::exception {
+private:
+  std::string m_msg;
+public:
+  ComponentNotFoundException() : m_msg(std::string("The given entity id does not exist.")){}
+
+  virtual const char* what() const throw() {
+    return m_msg.c_str();
+  }
+};
+
+#endif // FILE_ENTITY_NOT_FOUND_EXCEPTION_HPP

--- a/include/brickengine/entities/exceptions/entity_id_not_found.hpp
+++ b/include/brickengine/entities/exceptions/entity_id_not_found.hpp
@@ -1,0 +1,18 @@
+#ifndef FILE_ENTITY_NOT_FOUND_EXCEPTION_HPP
+#define FILE_ENTITY_NOT_FOUND_EXCEPTION_HPP
+
+#include <iostream>
+#include <exception>
+
+class EntityNotFoundException : public std::exception {
+private:
+  std::string m_msg;
+public:
+  GrandparentsNotSupportedException() : m_msg(std::string("The entity manager currently does not support grandparents.")){}
+
+  virtual const char* what() const throw() {
+    return m_msg.c_str();
+  }
+};
+
+#endif // FILE_ENTITY_NOT_FOUND_EXCEPTION_HPP

--- a/include/brickengine/entities/exceptions/entity_not_found.hpp
+++ b/include/brickengine/entities/exceptions/entity_not_found.hpp
@@ -1,0 +1,18 @@
+#ifndef FILE_ENTITY_NOT_FOUND_EXCEPTION_HPP
+#define FILE_ENTITY_NOT_FOUND_EXCEPTION_HPP
+
+#include <iostream>
+#include <exception>
+
+class EntityNotFoundException : public std::exception {
+private:
+  std::string m_msg;
+public:
+  EntityNotFoundException() : m_msg(std::string("The given entity id does not exist.")){}
+
+  virtual const char* what() const throw() {
+    return m_msg.c_str();
+  }
+};
+
+#endif // FILE_ENTITY_NOT_FOUND_EXCEPTION_HPP

--- a/include/brickengine/input.hpp
+++ b/include/brickengine/input.hpp
@@ -40,20 +40,20 @@ public:
     }
 
     // This function is intended for the UI so the game loop is not affected.
-    void popInput(int playerId, T const input) {
-        if(inputs[playerId].count(input))
-            inputs[playerId][input] = false;
+    void popInput(int player_id, T const input) {
+        if(inputs[player_id].count(input))
+            inputs[player_id][input] = false;
     }
 
-    bool checkInput(int playerId, T const input) {
-        if(inputs[playerId].count(input))
-            return inputs[playerId].at(input);
+    bool checkInput(int player_id, T const input) {
+        if(inputs[player_id].count(input))
+            return inputs[player_id].at(input);
         return false;
     }
 
-    bool remapInput(int playerId, T const input) {
+    bool remapInput(int player_id, T const input) {
         //Search for the old value
-        auto oldInput = std::find_if(input_mapping.at(playerId).begin(),input_mapping.at(playerId).end(),
+        auto oldInput = std::find_if(input_mapping.at(player_id).begin(),input_mapping.at(player_id).end(),
                                      [&input](const std::pair<InputKeyCode, T>& value) {
                                          return value.second == input;
                                      });
@@ -68,15 +68,15 @@ public:
                             return true;
                         }
                         //Input is not already used
-                        if(input_mapping.at(playerId).count(inputkeycode.value()) == 0)
+                        if(input_mapping.at(player_id).count(inputkeycode.value()) == 0)
                         {
-                            input_mapping[playerId][inputkeycode.value()] = input;
+                            input_mapping[player_id][inputkeycode.value()] = input;
                             //Removing old key mapping
-                            input_mapping.at(playerId).erase(oldInput->first);
+                            input_mapping.at(player_id).erase(oldInput->first);
                             return true; 
                         }
                         //Key is used
-                        if(input_mapping.at(playerId).count(inputkeycode.value()) == 1)
+                        if(input_mapping.at(player_id).count(inputkeycode.value()) == 1)
                             return false;
                     }
                 }
@@ -98,25 +98,25 @@ public:
                 case SDL_KEYDOWN:
                 case SDL_KEYUP:
                     // Checking if input is mapped.
-                    for(auto [playerId, mapping] : inputs){
+                    for(auto [player_id, mapping] : inputs){
                         std::ignore = mapping;
                         auto input = convertSDLKeycodeInputKeyCode(e.key.keysym.sym);
                         if(input.has_value()) {
-                            if(input_mapping.at(playerId).count(*input) && e.key.repeat == 0) {
+                            if(input_mapping.at(player_id).count(*input) && e.key.repeat == 0) {
                                 switch(e.type) {
                                     case SDL_KEYDOWN:
-                                        if (time_to_wait[playerId].count(input_mapping[playerId][*input])) {
-                                            auto& time_to_wait_for_key = time_to_wait[playerId][input_mapping[playerId][*input]];
+                                        if (time_to_wait[player_id].count(input_mapping[player_id][*input])) {
+                                            auto& time_to_wait_for_key = time_to_wait[player_id][input_mapping[player_id][*input]];
                                             if (time_to_wait_for_key.second >= time_to_wait_for_key.first) {
-                                                inputs[playerId][input_mapping[playerId][*input]] = true;
+                                                inputs[player_id][input_mapping[player_id][*input]] = true;
                                                 time_to_wait_for_key.second = 0;
                                             }
                                         } else {
-                                            inputs[playerId][input_mapping[playerId][*input]] = true;
+                                            inputs[player_id][input_mapping[player_id][*input]] = true;
                                         }
                                         break;
                                     case SDL_KEYUP:
-                                        inputs[playerId][input_mapping[playerId][*input]] = false;
+                                        inputs[player_id][input_mapping[player_id][*input]] = false;
                                     default:
                                         break;
                                 }
@@ -127,25 +127,25 @@ public:
                 case SDL_MOUSEBUTTONDOWN:
                 case SDL_MOUSEBUTTONUP:
                     // Checking if input is mapped.
-                    for(auto [playerId, mapping] : inputs){
+                    for(auto [player_id, mapping] : inputs){
                         std::ignore = mapping;
                         auto input = convertSDLKeycodeInputKeyCode(e.button.button);
                         if(input.has_value()) {
-                            if(input_mapping.at(playerId).count(*input)) {
+                            if(input_mapping.at(player_id).count(*input)) {
                                 switch(e.button.state) {
                                     case SDL_PRESSED:
-                                       if (time_to_wait[playerId].count(input_mapping[playerId][*input])) {
-                                            auto& time_to_wait_for_key = time_to_wait[playerId][input_mapping[playerId][*input]];
+                                       if (time_to_wait[player_id].count(input_mapping[player_id][*input])) {
+                                            auto& time_to_wait_for_key = time_to_wait[player_id][input_mapping[player_id][*input]];
                                             if (time_to_wait_for_key.second >= time_to_wait_for_key.first) {
-                                                inputs[playerId][input_mapping[playerId][*input]] = true;
+                                                inputs[player_id][input_mapping[player_id][*input]] = true;
                                                 time_to_wait_for_key.second = 0;
                                             }
                                         } else {
-                                            inputs[playerId][input_mapping[playerId][*input]] = true;
+                                            inputs[player_id][input_mapping[player_id][*input]] = true;
                                         }
                                         break;
                                     case SDL_RELEASED:
-                                        inputs[playerId][input_mapping[playerId][*input]] = false;
+                                        inputs[player_id][input_mapping[player_id][*input]] = false;
                                     default:
                                         break;
                                 }

--- a/include/brickengine/input.hpp
+++ b/include/brickengine/input.hpp
@@ -53,7 +53,7 @@ public:
 
     bool remapInput(int player_id, T const input) {
         //Search for the old value
-        auto oldInput = std::find_if(input_mapping.at(player_id).begin(),input_mapping.at(player_id).end(),
+        auto old_input = std::find_if(input_mapping.at(player_id).begin(),input_mapping.at(player_id).end(),
                                      [&input](const std::pair<InputKeyCode, T>& value) {
                                          return value.second == input;
                                      });
@@ -61,22 +61,22 @@ public:
         while(true) {
             while(SDL_PollEvent(&e)) {
                 if(e.type == SDL_KEYDOWN) {
-                    auto inputkeycode = convertSDLKeycodeInputKeyCode(e.key.keysym.sym);
-                    if(inputkeycode.has_value()) {
+                    auto key_code = convertSDLKeycodeInputKeyCode(e.key.keysym.sym);
+                    if(key_code.has_value()) {
                         //Current key matches old key
-                        if(inputkeycode.value() == oldInput->first) {
+                        if(key_code.value() == old_input->first) {
                             return true;
                         }
                         //Input is not already used
-                        if(input_mapping.at(player_id).count(inputkeycode.value()) == 0)
+                        if(input_mapping.at(player_id).count(key_code.value()) == 0)
                         {
-                            input_mapping[player_id][inputkeycode.value()] = input;
+                            input_mapping[player_id][key_code.value()] = input;
                             //Removing old key mapping
-                            input_mapping.at(player_id).erase(oldInput->first);
+                            input_mapping.at(player_id).erase(old_input->first);
                             return true; 
                         }
                         //Key is used
-                        if(input_mapping.at(player_id).count(inputkeycode.value()) == 1)
+                        if(input_mapping.at(player_id).count(key_code.value()) == 1)
                             return false;
                     }
                 }

--- a/include/brickengine/input.hpp
+++ b/include/brickengine/input.hpp
@@ -241,6 +241,8 @@ private:
         // Special
         sdl_mapping.insert({InputKeyCode::EKey_lshift, SDLK_LSHIFT});
         sdl_mapping.insert({InputKeyCode::EKey_lctrl, SDLK_LCTRL});
+        sdl_mapping.insert({InputKeyCode::EKey_rshift, SDLK_RSHIFT});
+        sdl_mapping.insert({InputKeyCode::EKey_rctrl, SDLK_RCTRL});
         sdl_mapping.insert({InputKeyCode::EKey_space, SDLK_SPACE});
         sdl_mapping.insert({InputKeyCode::Ekey_enter, SDLK_KP_ENTER});
         sdl_mapping.insert({InputKeyCode::EKey_backspace, SDLK_BACKSPACE});
@@ -299,6 +301,8 @@ private:
         // Special
         keycode_mapping.insert({SDLK_LSHIFT, InputKeyCode::EKey_lshift});
         keycode_mapping.insert({SDLK_LCTRL, InputKeyCode::EKey_lctrl});
+        keycode_mapping.insert({SDLK_RSHIFT, InputKeyCode::EKey_rshift});
+        keycode_mapping.insert({SDLK_RCTRL, InputKeyCode::EKey_rctrl});
         keycode_mapping.insert({SDLK_SPACE, InputKeyCode::EKey_space});
         keycode_mapping.insert({SDLK_KP_ENTER, InputKeyCode::Ekey_enter});
         keycode_mapping.insert({SDLK_BACKSPACE, InputKeyCode::EKey_backspace});

--- a/include/brickengine/input_keycode.hpp
+++ b/include/brickengine/input_keycode.hpp
@@ -51,6 +51,8 @@ enum class InputKeyCode {
     // Special
     EKey_lshift,
     EKey_lctrl,
+    EKey_rshift,
+    EKey_rctrl,
     EKey_space,
     Ekey_enter,
     EKey_backspace,

--- a/include/brickengine/rendering/renderables/texture.hpp
+++ b/include/brickengine/rendering/renderables/texture.hpp
@@ -11,6 +11,12 @@ public:
     Texture(std::shared_ptr<SDL_Texture> texture, int layer, std::unique_ptr<Rect> dst);
     Texture(std::shared_ptr<SDL_Texture> texture, int layer, int alpha, std::unique_ptr<Rect> dst);
     Texture(std::shared_ptr<SDL_Texture> texture, int layer, std::unique_ptr<Rect> dst, std::unique_ptr<Rect> src);
+    Texture(const Texture& other);
+    Texture(Texture&& other) noexcept = delete;
+    Texture& operator=(Texture&& other) = delete;
+    Texture& operator=(const Texture& other) = delete;
+    // This can stay default because we don't own any pointers here
+    ~Texture() = default;
     void render(Renderer& r);
     virtual Rect* getSrcRect() const;
     virtual Rect* getDstRect() const;

--- a/include/brickengine/systems/physics_system.hpp
+++ b/include/brickengine/systems/physics_system.hpp
@@ -12,7 +12,7 @@ public:
     void update(double deltatime);
     void updateChildren(int parentId);
 private:
-    static constexpr double GRAVITY = 0.16;
+    static constexpr double GRAVITY = 23.04;
     static constexpr double TERMINAL_VELOCITY = 1000;
 
     std::shared_ptr<CollisionDetector> collisionDetector;

--- a/include/brickengine/systems/physics_system.hpp
+++ b/include/brickengine/systems/physics_system.hpp
@@ -12,7 +12,7 @@ public:
     void update(double deltatime);
     void updateChildren(int parentId);
 private:
-    static constexpr double GRAVITY = 23.04;
+    static constexpr double GRAVITY = 21.04;
     static constexpr double TERMINAL_VELOCITY = 1000;
 
     std::shared_ptr<CollisionDetector> collisionDetector;

--- a/lib/collision_detector.cpp
+++ b/lib/collision_detector.cpp
@@ -13,7 +13,18 @@
 
 CollisionDetector::CollisionDetector(std::shared_ptr<EntityManager> em) : entity_manager(em) {}
 
+void CollisionDetector::clearCache() {
+    space_left_cache.clear();
+    trigger_cache.clear();
+}
+
 CollisionReturnValues CollisionDetector::spaceLeft(int entity, Axis axis, Direction direction) {
+    if (space_left_cache.count(entity) && space_left_cache.at(entity).count(axis)
+        && space_left_cache.at(entity).at(axis).count(direction)) {
+        space_left_cache_hits++;
+        return space_left_cache.at(entity).at(axis).at(direction);
+    }
+
     // We only support rectangles
     auto entity_rect_collider = entity_manager->getComponent<RectangleColliderComponent>(entity);
     auto [ entity_position, entity_scale ] = entity_manager->getAbsoluteTransform(entity);
@@ -38,13 +49,15 @@ CollisionReturnValues CollisionDetector::spaceLeft(int entity, Axis axis, Direct
         if (children.count(other_id)) continue;
         if (other_id == entity) continue;
 
+        space_left_calculated_counter++;
+
         auto [ other_position, other_scale ] = entity_manager->getAbsoluteTransform(other_id);
 
         if(axis == Axis::X) {
-            int yStartEntity = entity_position.y - ((entity_scale.y * entity_rect_collider->yScale) / 2);
-            int yEndEntity = entity_position.y + ((entity_scale.y * entity_rect_collider->yScale) / 2);
-            int yStartCollidable = other_position.y - ((other_scale.y * collider->yScale) / 2);
-            int yEndCollidable = other_position.y + ((other_scale.y * collider->yScale) / 2);
+            int yStartEntity = entity_position.y - ((entity_scale.y * entity_rect_collider->y_scale) / 2);
+            int yEndEntity = entity_position.y + ((entity_scale.y * entity_rect_collider->y_scale) / 2);
+            int yStartCollidable = other_position.y - ((other_scale.y * collider->y_scale) / 2);
+            int yEndCollidable = other_position.y + ((other_scale.y * collider->y_scale) / 2);
 
             if(direction == Direction::POSITIVE) { // Right
                 /**
@@ -53,15 +66,15 @@ CollisionReturnValues CollisionDetector::spaceLeft(int entity, Axis axis, Direct
 
                 if(yStartEntity < yEndCollidable && yStartCollidable < yEndEntity) {
                     // Entities align on y-axis
-                    double opposibleColliderHitwall = other_position.x - ((other_scale.x * collider->xScale) / 2);
-                    double entityColliderHitwall = entity_position.x + ((entity_scale.x * entity_rect_collider->xScale) / 2);
+                    double opposibleColliderHitwall = other_position.x - ((other_scale.x * collider->x_scale) / 2);
+                    double entityColliderHitwall = entity_position.x + ((entity_scale.x * entity_rect_collider->x_scale) / 2);
 
                     double difference = opposibleColliderHitwall - entityColliderHitwall;
 
                     if(difference >= 0 && space_left > difference) {
                         space_left = difference;
                         object_id = other_id;
-                        is_trigger = collider->isTrigger;
+                        is_trigger = collider->is_trigger;
                     }
                 }
             } else if(direction == Direction::NEGATIVE) { // Left
@@ -71,23 +84,23 @@ CollisionReturnValues CollisionDetector::spaceLeft(int entity, Axis axis, Direct
 
                 if(yStartEntity < yEndCollidable && yStartCollidable < yEndEntity) {
                     // Entities align on y-axiss
-                    double opposibleColliderHitwall = other_position.x + ((other_scale.x * collider->xScale) / 2);
-                    double entityColliderHitwall = entity_position.x - ((entity_scale.x * entity_rect_collider->xScale) / 2);
+                    double opposibleColliderHitwall = other_position.x + ((other_scale.x * collider->x_scale) / 2);
+                    double entityColliderHitwall = entity_position.x - ((entity_scale.x * entity_rect_collider->x_scale) / 2);
                     
                     double difference = opposibleColliderHitwall - entityColliderHitwall;
 
                     if(difference <= 0 && space_left < difference){
                         space_left = difference;
                         object_id = other_id;
-                        is_trigger = collider->isTrigger;
+                        is_trigger = collider->is_trigger;
                     }
                 }
             }
         } else if(axis == Axis::Y) {
-            int xStartEntity = entity_position.x - ((entity_scale.x * entity_rect_collider->xScale) / 2);
-            int xEndEntity = entity_position.x + ((entity_scale.x * entity_rect_collider->xScale) / 2);
-            int xStartCollidable = other_position.x - ((other_scale.x * collider->xScale) / 2);
-            int xEndCollidable = other_position.x + ((other_scale.x * collider->xScale) / 2);
+            int xStartEntity = entity_position.x - ((entity_scale.x * entity_rect_collider->x_scale) / 2);
+            int xEndEntity = entity_position.x + ((entity_scale.x * entity_rect_collider->x_scale) / 2);
+            int xStartCollidable = other_position.x - ((other_scale.x * collider->x_scale) / 2);
+            int xEndCollidable = other_position.x + ((other_scale.x * collider->x_scale) / 2);
 
             if(direction == Direction::POSITIVE) { // Down
                 /**
@@ -95,15 +108,15 @@ CollisionReturnValues CollisionDetector::spaceLeft(int entity, Axis axis, Direct
                     **/
                 if(xStartEntity < xEndCollidable && xStartCollidable < xEndEntity) {
                     // Entities align on x-axis
-                    double opposibleColliderHitwall = other_position.y - ((other_scale.y * collider->yScale) / 2);
-                    double entityColliderHitwall = entity_position.y + ((entity_scale.y * entity_rect_collider->yScale) / 2);
+                    double opposibleColliderHitwall = other_position.y - ((other_scale.y * collider->y_scale) / 2);
+                    double entityColliderHitwall = entity_position.y + ((entity_scale.y * entity_rect_collider->y_scale) / 2);
                     
                     double difference = opposibleColliderHitwall - entityColliderHitwall;
 
                     if(difference >= 0 && space_left > difference){
                         space_left = difference;
                         object_id = other_id;
-                        is_trigger = collider->isTrigger;
+                        is_trigger = collider->is_trigger;
                     }
                 }
             } else if(direction == Direction::NEGATIVE) { // Up
@@ -112,24 +125,32 @@ CollisionReturnValues CollisionDetector::spaceLeft(int entity, Axis axis, Direct
                     **/
                 if(xStartEntity < xEndCollidable && xStartCollidable < xEndEntity) {
                     // Entities align on x-axis
-                    double opposibleColliderHitwall = other_position.y + ((other_scale.y * collider->yScale) / 2);
-                    double entityColliderHitwall = entity_position.y - ((entity_scale.y * entity_rect_collider->yScale) / 2);
+                    double opposibleColliderHitwall = other_position.y + ((other_scale.y * collider->y_scale) / 2);
+                    double entityColliderHitwall = entity_position.y - ((entity_scale.y * entity_rect_collider->y_scale) / 2);
 
                     double difference = opposibleColliderHitwall - entityColliderHitwall;
 
                     if(difference <= 0 && space_left < difference){
                         space_left = difference;
                         object_id = other_id;
-                        is_trigger = collider->isTrigger;
+                        is_trigger = collider->is_trigger;
                     }
                 } 
             }
         }        
     }    
-    return CollisionReturnValues(space_left, object_id, is_trigger);
+    auto collision =  CollisionReturnValues(space_left, object_id, is_trigger);
+    space_left_cache.insert({ entity, std::unordered_map<Axis, std::unordered_map<Direction, CollisionReturnValues>>() });
+    space_left_cache.at(entity).insert({ axis, std::unordered_map<Direction, CollisionReturnValues>() });
+    space_left_cache.at(entity).at(axis).insert({ direction, collision });
+    return collision;
 }
 
 TriggerReturnValues CollisionDetector::isInTrigger(int entity){
+    if (trigger_cache.count(entity)) {
+        trigger_cache_hits++;
+        return trigger_cache.at(entity);
+    }
     // We only support rectangles
     auto entity_rect_collider = entity_manager->getComponent<RectangleColliderComponent>(entity);
     auto entity_transform = entity_manager->getComponent<TransformComponent>(entity);
@@ -145,18 +166,19 @@ TriggerReturnValues CollisionDetector::isInTrigger(int entity){
         if (parent && *parent == id) continue;
         if (children.count(id)) continue;
 
+        trigger_calculated_counter++;
         auto transform_component = entity_manager->getComponent<TransformComponent>(id);
 
-        if(collider->isTrigger){
-            double opposible_left = transform_component->xPos - ((transform_component->xScale * collider->xScale) / 2);
-            double opposible_right = transform_component->xPos + ((transform_component->xScale * collider->xScale) / 2);
-            double opposible_down = transform_component->yPos - ((transform_component->yScale * collider->yScale) / 2);
-            double opposible_up = transform_component->yPos + ((transform_component->yScale * collider->yScale) / 2);
+        if(collider->is_trigger){
+            double opposible_left = transform_component->xPos - ((transform_component->xScale * collider->x_scale) / 2);
+            double opposible_right = transform_component->xPos + ((transform_component->xScale * collider->x_scale) / 2);
+            double opposible_down = transform_component->yPos - ((transform_component->yScale * collider->y_scale) / 2);
+            double opposible_up = transform_component->yPos + ((transform_component->yScale * collider->y_scale) / 2);
 
-            double entity_left = entity_transform->xPos + ((entity_transform->xScale * entity_rect_collider->xScale) / 2);
-            double entity_right = entity_transform->xPos - ((entity_transform->xScale * entity_rect_collider->xScale) / 2);
-            double entity_down = entity_transform->yPos + ((entity_transform->yScale * entity_rect_collider->yScale) / 2);
-            double entity_up = entity_transform->yPos - ((entity_transform->yScale * entity_rect_collider->yScale) / 2);
+            double entity_left = entity_transform->xPos + ((entity_transform->xScale * entity_rect_collider->x_scale) / 2);
+            double entity_right = entity_transform->xPos - ((entity_transform->xScale * entity_rect_collider->x_scale) / 2);
+            double entity_down = entity_transform->yPos + ((entity_transform->yScale * entity_rect_collider->y_scale) / 2);
+            double entity_up = entity_transform->yPos - ((entity_transform->yScale * entity_rect_collider->y_scale) / 2);
 
             // Check if you are inside the x and y of the collidable
             if(entity_left >= opposible_left 
@@ -168,6 +190,7 @@ TriggerReturnValues CollisionDetector::isInTrigger(int entity){
             }
         }
     }
+    trigger_cache.insert({ entity, values});
     return values;
 }
 

--- a/lib/collision_detector.cpp
+++ b/lib/collision_detector.cpp
@@ -170,15 +170,15 @@ TriggerReturnValues CollisionDetector::isInTrigger(int entity){
         auto transform_component = entity_manager->getComponent<TransformComponent>(id);
 
         if(collider->is_trigger){
-            double opposible_left = transform_component->xPos - ((transform_component->xScale * collider->x_scale) / 2);
-            double opposible_right = transform_component->xPos + ((transform_component->xScale * collider->x_scale) / 2);
-            double opposible_down = transform_component->yPos - ((transform_component->yScale * collider->y_scale) / 2);
-            double opposible_up = transform_component->yPos + ((transform_component->yScale * collider->y_scale) / 2);
+            double opposible_left = transform_component->x_pos - ((transform_component->x_scale * collider->x_scale) / 2);
+            double opposible_right = transform_component->x_pos + ((transform_component->x_scale * collider->x_scale) / 2);
+            double opposible_down = transform_component->y_pos - ((transform_component->y_scale * collider->y_scale) / 2);
+            double opposible_up = transform_component->y_pos + ((transform_component->y_scale * collider->y_scale) / 2);
 
-            double entity_left = entity_transform->xPos + ((entity_transform->xScale * entity_rect_collider->x_scale) / 2);
-            double entity_right = entity_transform->xPos - ((entity_transform->xScale * entity_rect_collider->x_scale) / 2);
-            double entity_down = entity_transform->yPos + ((entity_transform->yScale * entity_rect_collider->y_scale) / 2);
-            double entity_up = entity_transform->yPos - ((entity_transform->yScale * entity_rect_collider->y_scale) / 2);
+            double entity_left = entity_transform->x_pos + ((entity_transform->x_scale * entity_rect_collider->x_scale) / 2);
+            double entity_right = entity_transform->x_pos - ((entity_transform->x_scale * entity_rect_collider->x_scale) / 2);
+            double entity_down = entity_transform->y_pos + ((entity_transform->y_scale * entity_rect_collider->y_scale) / 2);
+            double entity_up = entity_transform->y_pos - ((entity_transform->y_scale * entity_rect_collider->y_scale) / 2);
 
             // Check if you are inside the x and y of the collidable
             if(entity_left >= opposible_left 

--- a/lib/collision_detector.cpp
+++ b/lib/collision_detector.cpp
@@ -43,7 +43,7 @@ CollisionReturnValues CollisionDetector::spaceLeft(int entity, Axis axis, Direct
         space_left = std::numeric_limits<double>::infinity();
     }
 
-    for(auto& [ other_id, collider ] : *collidable_entities) {
+    for(auto& [ other_id, collider ] : collidable_entities) {
         // You cannot collide with family
         if (parent && *parent == other_id) continue;
         if (children.count(other_id)) continue;
@@ -161,7 +161,7 @@ TriggerReturnValues CollisionDetector::isInTrigger(int entity){
 
     auto values = TriggerReturnValues(false, std::nullopt);
 
-    for(auto& [id, collider] : *collidable_entities) {
+    for(auto& [id, collider] : collidable_entities) {
         // You cannot trigger with family
         if (parent && *parent == id) continue;
         if (children.count(id)) continue;

--- a/lib/collision_detector.cpp
+++ b/lib/collision_detector.cpp
@@ -21,7 +21,7 @@ void CollisionDetector::clearCache() {
 CollisionReturnValues CollisionDetector::spaceLeft(int entity, Axis axis, Direction direction) {
     if (space_left_cache.count(entity) && space_left_cache.at(entity).count(axis)
         && space_left_cache.at(entity).at(axis).count(direction)) {
-        space_left_cache_hits++;
+        ++space_left_cache_hits;
         return space_left_cache.at(entity).at(axis).at(direction);
     }
 
@@ -49,7 +49,7 @@ CollisionReturnValues CollisionDetector::spaceLeft(int entity, Axis axis, Direct
         if (children.count(other_id)) continue;
         if (other_id == entity) continue;
 
-        space_left_calculated_counter++;
+        ++space_left_calculated_counter;
 
         auto [ other_position, other_scale ] = entity_manager->getAbsoluteTransform(other_id);
 
@@ -148,7 +148,7 @@ CollisionReturnValues CollisionDetector::spaceLeft(int entity, Axis axis, Direct
 
 TriggerReturnValues CollisionDetector::isInTrigger(int entity){
     if (trigger_cache.count(entity)) {
-        trigger_cache_hits++;
+        ++trigger_cache_hits;
         return trigger_cache.at(entity);
     }
     // We only support rectangles
@@ -166,7 +166,7 @@ TriggerReturnValues CollisionDetector::isInTrigger(int entity){
         if (parent && *parent == id) continue;
         if (children.count(id)) continue;
 
-        trigger_calculated_counter++;
+        ++trigger_calculated_counter;
         auto transform_component = entity_manager->getComponent<TransformComponent>(id);
 
         if(collider->is_trigger){

--- a/lib/collision_detector.cpp
+++ b/lib/collision_detector.cpp
@@ -42,7 +42,7 @@ CollisionReturnValues CollisionDetector::spaceLeft(int entity, Axis axis, Direct
     } else {
         space_left = std::numeric_limits<double>::infinity();
     }
-    
+
     for(auto& [ other_id, collider ] : *collidable_entities) {
         // You cannot collide with family
         if (parent && *parent == other_id) continue;
@@ -110,7 +110,7 @@ CollisionReturnValues CollisionDetector::spaceLeft(int entity, Axis axis, Direct
                     // Entities align on x-axis
                     double opposibleColliderHitwall = other_position.y - ((other_scale.y * collider->y_scale) / 2);
                     double entityColliderHitwall = entity_position.y + ((entity_scale.y * entity_rect_collider->y_scale) / 2);
-                    
+
                     double difference = opposibleColliderHitwall - entityColliderHitwall;
 
                     if(difference >= 0 && space_left > difference){
@@ -182,9 +182,9 @@ TriggerReturnValues CollisionDetector::isInTrigger(int entity){
 
             // Check if you are inside the x and y of the collidable
             if(entity_left >= opposible_left 
-            && entity_right <= opposible_right
-            && entity_down >= opposible_down
-            && entity_up <= opposible_up){
+                && entity_right <= opposible_right
+                && entity_down >= opposible_down
+                && entity_up <= opposible_up) {
                 values.is_in_trigger = true;
                 values.object_id = id;
             }

--- a/lib/components/colliders/rectangle_collider_component.cpp
+++ b/lib/components/colliders/rectangle_collider_component.cpp
@@ -1,7 +1,7 @@
 #include "brickengine/components/colliders/rectangle_collider_component.hpp"
 
 RectangleColliderComponent::RectangleColliderComponent(double xScale, double yScale, double zScale, bool isTrigger)
-    : xScale(xScale), yScale(yScale), zScale(zScale), isTrigger(isTrigger) {}
+    : x_scale(xScale), y_scale(yScale), z_scale(zScale), is_trigger(isTrigger) {}
 
 std::string RectangleColliderComponent::getNameStatic() {
     return "RectangleColliderComponent";

--- a/lib/components/player_component.cpp
+++ b/lib/components/player_component.cpp
@@ -1,7 +1,7 @@
 #include "brickengine/components/player_component.hpp"
 
-PlayerComponent::PlayerComponent(int playerId)
-                    : playerId(playerId) {}
+PlayerComponent::PlayerComponent(int player_id, bool disabled)
+    : player_id(player_id), disabled(disabled) {}
 
 std::string PlayerComponent::getNameStatic() {
     return "PlayerComponent";

--- a/lib/components/renderables/texture_component.cpp
+++ b/lib/components/renderables/texture_component.cpp
@@ -2,6 +2,16 @@
 
 TextureComponent::TextureComponent(std::unique_ptr<Texture> t) : texture(std::move(t)) {}
 
+TextureComponent::TextureComponent(const TextureComponent& other) {
+    this->texture = std::make_unique<Texture>(*other.texture);
+}
+TextureComponent& TextureComponent::operator=(const TextureComponent& other) {
+    if (this != &other) {
+        this->texture = std::make_unique<Texture>(*other.texture);
+    }
+    return *this;
+}
+
 std::string TextureComponent::getNameStatic() {
     return "TextureComponent";
 }

--- a/lib/components/transform_component.cpp
+++ b/lib/components/transform_component.cpp
@@ -1,7 +1,7 @@
 #include "brickengine/components/transform_component.hpp"
 
-TransformComponent::TransformComponent(double xPos, double yPos, double xScale, double yScale, Direction xDirection, Direction yDirection)
-                    : xPos(xPos), yPos(yPos), xScale(xScale), yScale(yScale), xDirection(xDirection), yDirection(yDirection) {}
+TransformComponent::TransformComponent(double x_pos, double y_pos, double x_scale, double y_scale, Direction x_direction, Direction y_direction)
+                    : x_pos(x_pos), y_pos(y_pos), x_scale(x_scale), y_scale(y_scale), x_direction(x_direction), y_direction(y_direction) {}
 
 std::string TransformComponent::getNameStatic() {
     return "TransformComponent";

--- a/lib/rendering/renderables/texture.cpp
+++ b/lib/rendering/renderables/texture.cpp
@@ -16,6 +16,15 @@ Texture::Texture(std::shared_ptr<SDL_Texture> texture, int layer, std::unique_pt
     Renderable(layer), texture(std::move(texture)),
     src(std::move(src)), dst(std::move(dst)), flip(SDL_FLIP_NONE) {}
 
+Texture::Texture(const Texture& other) : Renderable(other.layer) {
+    this->texture = other.texture;
+    if (other.src)
+        this->src = std::make_unique<Rect>(*other.src);
+    if (other.dst)
+        this->dst = std::make_unique<Rect>(*other.dst);
+    this->flip = other.flip;
+}
+
 void Texture::render(Renderer& r) {
     r.render(*this);
 }

--- a/lib/rendering/renderer.cpp
+++ b/lib/rendering/renderer.cpp
@@ -58,7 +58,7 @@ SDL_Texture* Renderer::createTextureFromSurface(SDL_Surface* surface) const {
 }
 
 void Renderer::drawScreen() {
-    for(size_t i = 0; i < layers.size(); i++) {
+    for(size_t i = 0; i < layers.size(); ++i) {
         for (auto r : this->renderQueue.get()->at(layers[i])) {
             SDL_Color prev;
             SDL_BlendMode mode;

--- a/lib/systems/physics_system.cpp
+++ b/lib/systems/physics_system.cpp
@@ -22,18 +22,17 @@ void PhysicsSystem::update(double deltatime) {
         double mass = physics->mass;
 
         if (physics->gravity) {
-            // Also do collisions
-            double vy = physics->vy + (GRAVITY * mass);
+            double slow_down_amount = ((GRAVITY * mass) * deltatime);
+            double vy_gravity = physics->vy + slow_down_amount;
 
-            if (vy > TERMINAL_VELOCITY)
-                vy = TERMINAL_VELOCITY;
-            
-            physics->vy = vy;
+            if (vy_gravity > TERMINAL_VELOCITY)
+                vy_gravity = TERMINAL_VELOCITY;
+            physics->vy = vy_gravity;
         }
 
         double vx = physics->vx * deltatime;
         double vy = physics->vy * deltatime;
-        
+
         if (physics->vx > 0) { // Moving right
             if (physics->flipX)
                 transform->xDirection = Direction::POSITIVE;
@@ -79,7 +78,7 @@ void PhysicsSystem::update(double deltatime) {
                 transform->yDirection = Direction::POSITIVE;
 
             auto collision = collisionDetector->spaceLeft(entityId, Axis::Y, Direction::POSITIVE);
-            
+
             if (collision.space_left == 0){
                 physics->vy = 0;
             } else {
@@ -99,7 +98,7 @@ void PhysicsSystem::update(double deltatime) {
                 transform->yDirection = Direction::NEGATIVE;
 
             auto collision = collisionDetector->spaceLeft(entityId, Axis::Y, Direction::NEGATIVE);
-            
+
             if (collision.space_left == 0){
                 physics->vy = 0;
             } else {

--- a/lib/systems/physics_system.cpp
+++ b/lib/systems/physics_system.cpp
@@ -39,7 +39,7 @@ void PhysicsSystem::update(double deltatime) {
 
             auto collision = collisionDetector->spaceLeft(entityId, Axis::X, Direction::POSITIVE);
 
-            if (collision.space_left == 0){
+            if (collision.space_left == 0 && !collision.is_trigger) {
                 physics->vx = 0;
             } else {
                 double toMove = vx;
@@ -59,7 +59,7 @@ void PhysicsSystem::update(double deltatime) {
 
             auto collision = collisionDetector->spaceLeft(entityId, Axis::X, Direction::NEGATIVE);
             
-            if (collision.space_left == 0){
+            if (collision.space_left == 0 && !collision.is_trigger) {
                 physics->vx = 0;
             } else {
                 double toMove = vx;
@@ -79,7 +79,7 @@ void PhysicsSystem::update(double deltatime) {
 
             auto collision = collisionDetector->spaceLeft(entityId, Axis::Y, Direction::POSITIVE);
 
-            if (collision.space_left == 0){
+            if (collision.space_left == 0 && !collision.is_trigger) {
                 physics->vy = 0;
             } else {
                 double toMove = vy;
@@ -99,7 +99,7 @@ void PhysicsSystem::update(double deltatime) {
 
             auto collision = collisionDetector->spaceLeft(entityId, Axis::Y, Direction::NEGATIVE);
 
-            if (collision.space_left == 0){
+            if (collision.space_left == 0 && !collision.is_trigger) {
                 physics->vy = 0;
             } else {
                 double toMove = vy;

--- a/lib/systems/physics_system.cpp
+++ b/lib/systems/physics_system.cpp
@@ -10,7 +10,7 @@ PhysicsSystem::PhysicsSystem(std::shared_ptr<CollisionDetector> cd, std::shared_
 void PhysicsSystem::update(double deltatime) {
     auto entitiesWithPhysics = entityManager->getEntitiesByComponent<PhysicsComponent>();
 
-    for(auto [entityId, physics] : *entitiesWithPhysics){
+    for(auto [entityId, physics] : entitiesWithPhysics){
         if (physics->kinematic != Kinematic::IS_NOT_KINEMATIC) {
             physics->vx = 0;
             physics->vy = 0;

--- a/lib/systems/physics_system.cpp
+++ b/lib/systems/physics_system.cpp
@@ -35,7 +35,7 @@ void PhysicsSystem::update(double deltatime) {
 
         if (physics->vx > 0) { // Moving right
             if (physics->flipX)
-                transform->xDirection = Direction::POSITIVE;
+                transform->x_direction = Direction::POSITIVE;
 
             auto collision = collisionDetector->spaceLeft(entityId, Axis::X, Direction::POSITIVE);
 
@@ -50,12 +50,12 @@ void PhysicsSystem::update(double deltatime) {
                 else 
                     toMove = vx;
 
-                transform->xPos = transform->xPos + toMove;
+                transform->x_pos = transform->x_pos + toMove;
             }
         }
         if (physics->vx < 0) { // Moving left
             if (physics->flipX)
-                transform->xDirection = Direction::NEGATIVE;
+                transform->x_direction = Direction::NEGATIVE;
 
             auto collision = collisionDetector->spaceLeft(entityId, Axis::X, Direction::NEGATIVE);
             
@@ -70,12 +70,12 @@ void PhysicsSystem::update(double deltatime) {
                 else 
                     toMove = vx;
 
-                transform->xPos = transform->xPos + toMove;
+                transform->x_pos = transform->x_pos + toMove;
             }
         }
         if (physics->vy > 0) { // Moving down
             if (physics->flipY)
-                transform->yDirection = Direction::POSITIVE;
+                transform->y_direction = Direction::POSITIVE;
 
             auto collision = collisionDetector->spaceLeft(entityId, Axis::Y, Direction::POSITIVE);
 
@@ -90,12 +90,12 @@ void PhysicsSystem::update(double deltatime) {
                 else 
                     toMove = vy;
 
-                transform->yPos = transform->yPos + toMove;
+                transform->y_pos = transform->y_pos + toMove;
             }
         }
         if (physics->vy < 0) { // Moving up
             if (physics->flipY)
-                transform->yDirection = Direction::NEGATIVE;
+                transform->y_direction = Direction::NEGATIVE;
 
             auto collision = collisionDetector->spaceLeft(entityId, Axis::Y, Direction::NEGATIVE);
 
@@ -110,7 +110,7 @@ void PhysicsSystem::update(double deltatime) {
                 else 
                     toMove = vy;
 
-                transform->yPos = transform->yPos + toMove;
+                transform->y_pos = transform->y_pos + toMove;
             }
         }
         updateChildren(entityId);
@@ -128,14 +128,14 @@ void PhysicsSystem::updateChildren(int parentId) {
         auto transformChild = entityManager->getComponent<TransformComponent>(child);
 
         if (childPhysics->flipX) {
-            if (transformChild->xDirection != transformParent->xDirection)
-                transformChild->xPos *= -1;
-            transformChild->xDirection = transformParent->xDirection;
+            if (transformChild->x_direction != transformParent->x_direction)
+                transformChild->x_pos *= -1;
+            transformChild->x_direction = transformParent->x_direction;
         }
         if (childPhysics->flipY) {
-            if (transformChild->yDirection != transformParent->yDirection)
-                transformChild->yPos *= -1;
-            transformChild->yDirection = transformParent->yDirection;
+            if (transformChild->y_direction != transformParent->y_direction)
+                transformChild->y_pos *= -1;
+            transformChild->y_direction = transformParent->y_direction;
         }
 
         updateChildren(child);

--- a/lib/systems/physics_system.cpp
+++ b/lib/systems/physics_system.cpp
@@ -22,7 +22,7 @@ void PhysicsSystem::update(double deltatime) {
         double mass = physics->mass;
 
         if (physics->gravity) {
-            double slow_down_amount = ((GRAVITY * mass) * deltatime);
+            double slow_down_amount = (GRAVITY * mass) * deltatime;
             double vy_gravity = physics->vy + slow_down_amount;
 
             if (vy_gravity > TERMINAL_VELOCITY)

--- a/lib/systems/physics_system.cpp
+++ b/lib/systems/physics_system.cpp
@@ -18,6 +18,7 @@ void PhysicsSystem::update(double deltatime) {
         }
 
         auto transform = entityManager->getComponent<TransformComponent>(entityId);
+        // TODO make it so trigger goes through everything instead of only checking if player can move through trigger
         double mass = physics->mass;
 
         if (physics->gravity) {
@@ -38,7 +39,7 @@ void PhysicsSystem::update(double deltatime) {
                 transform->xDirection = Direction::POSITIVE;
 
             auto collision = collisionDetector->spaceLeft(entityId, Axis::X, Direction::POSITIVE);
-            
+
             if (collision.space_left == 0){
                 physics->vx = 0;
             } else {

--- a/lib/systems/rendering_system.cpp
+++ b/lib/systems/rendering_system.cpp
@@ -22,11 +22,11 @@ void RenderingSystem::update(double){
         texture->getTexture()->setFlip(SDL_FLIP_NONE);
         SDL_RendererFlip flip = SDL_FLIP_NONE;
 
-        if (transform->xDirection == Direction::NEGATIVE && transform->yDirection == Direction::NEGATIVE) {
+        if (transform->x_direction == Direction::NEGATIVE && transform->y_direction == Direction::NEGATIVE) {
             flip = static_cast<SDL_RendererFlip>(SDL_FLIP_HORIZONTAL | SDL_FLIP_VERTICAL);
-        } else if (transform->xDirection == Direction::NEGATIVE) {
+        } else if (transform->x_direction == Direction::NEGATIVE) {
             flip = SDL_FLIP_HORIZONTAL;
-        } else if (transform->yDirection == Direction::NEGATIVE) {
+        } else if (transform->y_direction == Direction::NEGATIVE) {
             flip = SDL_FLIP_VERTICAL;
         }
 

--- a/lib/systems/rendering_system.cpp
+++ b/lib/systems/rendering_system.cpp
@@ -9,7 +9,7 @@ RenderingSystem::RenderingSystem(std::shared_ptr<EntityManager> entityManager, R
 void RenderingSystem::update(double){
     auto entitiesWithTexture = entityManager->getEntitiesByComponent<TextureComponent>();
 
-    for(auto& [entityId, texture] : *entitiesWithTexture) {
+    for(auto& [entityId, texture] : entitiesWithTexture) {
         auto transform = entityManager->getComponent<TransformComponent>(entityId);
 
         auto dst = texture->getTexture()->getDstRect();

--- a/tests/entities/entity_manager_parent_child_test.cpp
+++ b/tests/entities/entity_manager_parent_child_test.cpp
@@ -17,10 +17,10 @@ TEST(EntityManager_Family, create_entity_with_parent_already_relative) {
     int child = em.createEntity(std::move(child_comps), std::make_pair(parent, true));
 
     EXPECT_EQ(parent, em.getParent(child));
-    EXPECT_EQ(10, em.getComponent<TransformComponent>(child)->xPos);
-    EXPECT_EQ(5, em.getComponent<TransformComponent>(child)->yPos);
-    EXPECT_EQ(3, em.getComponent<TransformComponent>(child)->xScale);
-    EXPECT_EQ(2, em.getComponent<TransformComponent>(child)->yScale);
+    EXPECT_EQ(10, em.getComponent<TransformComponent>(child)->x_pos);
+    EXPECT_EQ(5, em.getComponent<TransformComponent>(child)->y_pos);
+    EXPECT_EQ(3, em.getComponent<TransformComponent>(child)->x_scale);
+    EXPECT_EQ(2, em.getComponent<TransformComponent>(child)->y_scale);
 }
 TEST(EntityManager_Family, create_entity_with_parent_not_yet_relative) {
     EntityManager em;
@@ -33,10 +33,10 @@ TEST(EntityManager_Family, create_entity_with_parent_not_yet_relative) {
     int child = em.createEntity(std::move(child_comps), std::make_pair(parent, false));
 
     EXPECT_EQ(parent, em.getParent(child));
-    EXPECT_EQ(-40, em.getComponent<TransformComponent>(child)->xPos);
-    EXPECT_EQ(-45, em.getComponent<TransformComponent>(child)->yPos);
-    EXPECT_EQ(1.5, em.getComponent<TransformComponent>(child)->xScale);
-    EXPECT_EQ(1, em.getComponent<TransformComponent>(child)->yScale);
+    EXPECT_EQ(-40, em.getComponent<TransformComponent>(child)->x_pos);
+    EXPECT_EQ(-45, em.getComponent<TransformComponent>(child)->y_pos);
+    EXPECT_EQ(1.5, em.getComponent<TransformComponent>(child)->x_scale);
+    EXPECT_EQ(1, em.getComponent<TransformComponent>(child)->y_scale);
 }
 TEST(EntityManager_Family, getAbsoluteTransform) {
     EntityManager em;

--- a/tests/entities/entity_manager_test.cpp
+++ b/tests/entities/entity_manager_test.cpp
@@ -33,7 +33,7 @@ TEST(EntityManager, create_entities_and_get_all_entities_by_comp) {
 
     auto entities = em.getEntitiesByComponent<TransformComponent>();
     
-    EXPECT_EQ(2, entities->size());
+    EXPECT_EQ(2, entities.size());
 }
 
 TEST(EntityManager, create_entity_and_remove_comp) {
@@ -65,7 +65,7 @@ TEST(EntityManager, create_entities_and_remove_one_comp) {
     auto entities = em.getEntitiesByComponent<TransformComponent>();
 
     
-    EXPECT_EQ(1, entities->size());
+    EXPECT_EQ(1, entities.size());
 }
 
 TEST(EntityManager, create_entities_and_remove_entity) {
@@ -85,7 +85,7 @@ TEST(EntityManager, create_entities_and_remove_entity) {
     auto entities = em.getEntitiesByComponent<TransformComponent>();
 
     
-    EXPECT_EQ(1, entities->size());
+    EXPECT_EQ(1, entities.size());
 }
 
 TEST(EntityManager, create_entities_and_add_component) {
@@ -102,7 +102,7 @@ TEST(EntityManager, create_entities_and_add_component) {
 
     auto entities = em.getEntitiesByComponent<PlayerComponent>();
     
-    EXPECT_EQ(1, entities->size());
+    EXPECT_EQ(1, entities.size());
 }
 
 TEST(EntityManager, add_component_that_already_exists) {
@@ -122,5 +122,5 @@ TEST(EntityManager, get_entities_when_component_is_not_used) {
 
     auto entites = em.getEntitiesByComponent<TransformComponent>();
 
-    EXPECT_EQ(0, entites->size());
+    EXPECT_EQ(0, entites.size());
 }

--- a/tests/entities/entity_manager_test.cpp
+++ b/tests/entities/entity_manager_test.cpp
@@ -115,7 +115,7 @@ TEST(EntityManager, add_component_that_already_exists) {
 
     auto x = em.getComponent<TransformComponent>(id);
 
-    EXPECT_EQ(1, x->xPos);
+    EXPECT_EQ(1, x->x_pos);
 }
 TEST(EntityManager, get_entities_when_component_is_not_used) {
     EntityManager em;


### PR DESCRIPTION
# Description

- Collision caching, improved performance with the collision detector, now only calculates the collision once per entity per update.

- ECS Tags, ability to give entities tags (for further use like giving platforms a tag so a trigger won't fall through it)

- Component cloning, when creating a bullet it will clone the components. We had to implement some Rule of Five things and only implemented those we actually needed and deleted the others. This cloning was only really possible because of the ResourceManager :sweat_smile:.

[Review with](https://github.com/Brick-Studios/BeastArena/pull/32)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Included 1 or more screenshots
- [x] Code is const correct
