### PR TITLE
Added SDL_Mixer

### DIFF
--- a/cmake/sdl2/FindSDL2_mixer.cmake
+++ b/cmake/sdl2/FindSDL2_mixer.cmake
@@ -1,0 +1,220 @@
+# Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
+# file Copyright.txt or https://cmake.org/licensing for details.
+
+#  Copyright 2019 Amine Ben Hassouna <amine.benhassouna@gmail.com>
+#  Copyright 2000-2019 Kitware, Inc. and Contributors
+#  All rights reserved.
+
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions
+#  are met:
+
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+
+#  * Neither the name of Kitware, Inc. nor the names of Contributors
+#    may be used to endorse or promote products derived from this
+#    software without specific prior written permission.
+
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+#  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+#  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+#  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+#  HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+#  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+#  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+#  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+#  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+#  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+#  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#[=======================================================================[.rst:
+FindSDL2_mixer
+--------------
+
+Locate SDL2_mixer library
+
+This module defines the following 'IMPORTED' target:
+
+::
+
+  SDL2::Mixer
+    The SDL2_mixer library, if found.
+    Have SDL2::Core as a link dependency.
+
+
+
+This module will set the following variables in your project:
+
+::
+
+  SDL2_MIXER_LIBRARIES, the name of the library to link against
+  SDL2_MIXER_INCLUDE_DIRS, where to find the headers
+  SDL2_MIXER_FOUND, if false, do not try to link against
+  SDL2_MIXER_VERSION_STRING - human-readable string containing the
+                              version of SDL2_mixer
+
+This module responds to the following cache variables:
+
+::
+
+  SDL2_MIXER_PATH
+    Set a custom SDL2_mixer Library path (default: empty)
+
+  SDL2_MIXER_NO_DEFAULT_PATH
+    Disable search SDL2_mixer Library in default path.
+      If SDL2_MIXER_PATH (default: ON)
+      Else (default: OFF)
+
+  SDL2_MIXER_INCLUDE_DIR
+    SDL2_mixer headers path.
+
+  SDL2_MIXER_LIBRARY
+    SDL2_mixer Library (.dll, .so, .a, etc) path.
+
+
+Additional Note: If you see an empty SDL2_MIXER_LIBRARY in your project
+configuration, it means CMake did not find your SDL2_mixer library
+(SDL2_mixer.dll, libsdl2_mixer.so, etc). Set SDL2_MIXER_LIBRARY to point
+to your SDL2_mixer library, and  configure again. This value is used to
+generate the final SDL2_MIXER_LIBRARIES variable and the SDL2::Mixer target,
+but when this value is unset, SDL2_MIXER_LIBRARIES and SDL2::Mixer does not
+get created.
+
+
+$SDL2MIXERDIR is an environment variable that would correspond to the
+./configure --prefix=$SDL2MIXERDIR used in building SDL2_mixer.
+
+$SDL2DIR is an environment variable that would correspond to the
+./configure --prefix=$SDL2DIR used in building SDL2.
+
+
+
+Created by Amine Ben Hassouna:
+  Adapt FindSDL_mixer.cmake to SDL2_mixer (FindSDL2_mixer.cmake).
+  Add cache variables for more flexibility:
+    SDL2_MIXER_PATH, SDL2_MIXER_NO_DEFAULT_PATH (for details, see doc above).
+  Add SDL2 as a required dependency.
+  Modernize the FindSDL2_mixer.cmake module by creating a specific target:
+    SDL2::Mixer (for details, see doc above).
+
+Original FindSDL_mixer.cmake module:
+  Created by Eric Wing.  This was influenced by the FindSDL.cmake
+  module, but with modifications to recognize OS X frameworks and
+  additional Unix paths (FreeBSD, etc).
+#]=======================================================================]
+
+# SDL2 Library required
+find_package(SDL2 QUIET)
+if(NOT SDL2_FOUND)
+  set(SDL2_MIXER_SDL2_NOT_FOUND "Could NOT find SDL2 (SDL2 is required by SDL2_mixer).")
+  if(SDL2_mixer_FIND_REQUIRED)
+    message(FATAL_ERROR ${SDL2_MIXER_SDL2_NOT_FOUND})
+  else()
+      if(NOT SDL2_mixer_FIND_QUIETLY)
+        message(STATUS ${SDL2_MIXER_SDL2_NOT_FOUND})
+      endif()
+    return()
+  endif()
+  unset(SDL2_MIXER_SDL2_NOT_FOUND)
+endif()
+
+
+# Define options for searching SDL2_mixer Library in a custom path
+
+set(SDL2_MIXER_PATH "" CACHE STRING "Custom SDL2_mixer Library path")
+
+set(_SDL2_MIXER_NO_DEFAULT_PATH OFF)
+if(SDL2_MIXER_PATH)
+  set(_SDL2_MIXER_NO_DEFAULT_PATH ON)
+endif()
+
+set(SDL2_MIXER_NO_DEFAULT_PATH ${_SDL2_MIXER_NO_DEFAULT_PATH}
+    CACHE BOOL "Disable search SDL2_mixer Library in default path")
+unset(_SDL2_MIXER_NO_DEFAULT_PATH)
+
+set(SDL2_MIXER_NO_DEFAULT_PATH_CMD)
+if(SDL2_MIXER_NO_DEFAULT_PATH)
+  set(SDL2_MIXER_NO_DEFAULT_PATH_CMD NO_DEFAULT_PATH)
+endif()
+
+# Search for the SDL2_mixer include directory
+find_path(SDL2_MIXER_INCLUDE_DIR SDL_mixer.h
+  HINTS
+    ENV SDL2MIXERDIR
+    ENV SDL2DIR
+    ${SDL2_MIXER_NO_DEFAULT_PATH_CMD}
+  PATH_SUFFIXES SDL2
+                # path suffixes to search inside ENV{SDL2DIR}
+                # and ENV{SDL2MIXERDIR}
+                include/SDL2 include
+  PATHS ${SDL2_MIXER_PATH}
+  DOC "Where the SDL2_mixer headers can be found"
+)
+
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+  set(VC_LIB_PATH_SUFFIX lib/x64)
+else()
+  set(VC_LIB_PATH_SUFFIX lib/x86)
+endif()
+
+# Search for the SDL2_mixer library
+find_library(SDL2_MIXER_LIBRARY
+  NAMES SDL2_mixer
+  HINTS
+    ENV SDL2MIXERDIR
+    ENV SDL2DIR
+    ${SDL2_MIXER_NO_DEFAULT_PATH_CMD}
+  PATH_SUFFIXES lib ${VC_LIB_PATH_SUFFIX}
+  PATHS ${SDL2_MIXER_PATH}
+  DOC "Where the SDL2_mixer Library can be found"
+)
+
+# Read SDL2_mixer version
+if(SDL2_MIXER_INCLUDE_DIR AND EXISTS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h")
+  file(STRINGS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h" SDL2_MIXER_VERSION_MAJOR_LINE REGEX "^#define[ \t]+SDL_MIXER_MAJOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h" SDL2_MIXER_VERSION_MINOR_LINE REGEX "^#define[ \t]+SDL_MIXER_MINOR_VERSION[ \t]+[0-9]+$")
+  file(STRINGS "${SDL2_MIXER_INCLUDE_DIR}/SDL_mixer.h" SDL2_MIXER_VERSION_PATCH_LINE REGEX "^#define[ \t]+SDL_MIXER_PATCHLEVEL[ \t]+[0-9]+$")
+  string(REGEX REPLACE "^#define[ \t]+SDL_MIXER_MAJOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_MIXER_VERSION_MAJOR "${SDL2_MIXER_VERSION_MAJOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL_MIXER_MINOR_VERSION[ \t]+([0-9]+)$" "\\1" SDL2_MIXER_VERSION_MINOR "${SDL2_MIXER_VERSION_MINOR_LINE}")
+  string(REGEX REPLACE "^#define[ \t]+SDL_MIXER_PATCHLEVEL[ \t]+([0-9]+)$" "\\1" SDL2_MIXER_VERSION_PATCH "${SDL2_MIXER_VERSION_PATCH_LINE}")
+  set(SDL2_MIXER_VERSION_STRING ${SDL2_MIXER_VERSION_MAJOR}.${SDL2_MIXER_VERSION_MINOR}.${SDL2_MIXER_VERSION_PATCH})
+  unset(SDL2_MIXER_VERSION_MAJOR_LINE)
+  unset(SDL2_MIXER_VERSION_MINOR_LINE)
+  unset(SDL2_MIXER_VERSION_PATCH_LINE)
+  unset(SDL2_MIXER_VERSION_MAJOR)
+  unset(SDL2_MIXER_VERSION_MINOR)
+  unset(SDL2_MIXER_VERSION_PATCH)
+endif()
+
+set(SDL2_MIXER_LIBRARIES ${SDL2_MIXER_LIBRARY})
+set(SDL2_MIXER_INCLUDE_DIRS ${SDL2_MIXER_INCLUDE_DIR})
+
+include(FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(SDL2_mixer
+                                  REQUIRED_VARS SDL2_MIXER_LIBRARIES SDL2_MIXER_INCLUDE_DIRS
+                                  VERSION_VAR SDL2_MIXER_VERSION_STRING)
+
+
+mark_as_advanced(SDL2_MIXER_PATH
+                 SDL2_MIXER_NO_DEFAULT_PATH
+                 SDL2_MIXER_LIBRARY
+                 SDL2_MIXER_INCLUDE_DIR)
+
+
+if(SDL2_MIXER_FOUND)
+
+  # SDL2::Mixer target
+  if(SDL2_MIXER_LIBRARY AND NOT TARGET SDL2::Mixer)
+    add_library(SDL2::Mixer UNKNOWN IMPORTED)
+    set_target_properties(SDL2::Mixer PROPERTIES
+                          IMPORTED_LOCATION "${SDL2_MIXER_LIBRARY}"
+                          INTERFACE_INCLUDE_DIRECTORIES "${SDL2_MIXER_INCLUDE_DIR}"
+                          INTERFACE_LINK_LIBRARIES SDL2::Core)
+  endif()
+endif()

--- a/include/brickengine/engine.hpp
+++ b/include/brickengine/engine.hpp
@@ -14,6 +14,7 @@
 #include "brickengine/rendering/renderer.hpp"
 #include "brickengine/rendering/renderable_factory.hpp"
 #include "brickengine/resource_manager.hpp"
+#include "brickengine/sound/sound_manager.hpp"
 
 class BrickEngine {
 public:
@@ -28,6 +29,7 @@ public:
     void drawFpsCounter();
     RenderableFactory* getRenderableFactory() const;
     Renderer* getRenderer() const;
+    SoundManager& getSoundManager() const;
     int getFps() const;
     double getDeltatime() const;
     EngineTick getTicks() const;
@@ -48,6 +50,7 @@ private:
     std::unique_ptr<RenderableFactory> renderableFactory;
     std::shared_ptr<Renderer> renderer;
     std::shared_ptr<ResourceManager> resource_manager;
+    std::unique_ptr<SoundManager> sound_manager;
 };
 
 #endif // FILE_BRICKENGINE_HPP

--- a/include/brickengine/sound/sound_manager.hpp
+++ b/include/brickengine/sound/sound_manager.hpp
@@ -1,0 +1,20 @@
+#ifndef FILE_SOUND_MANAGER_HPP
+#define FILE_SOUND_MANAGER_HPP
+
+#include <string>
+
+#include "SDL2/SDL_mixer.h"
+
+class SoundManager {
+public:
+    SoundManager();
+    ~SoundManager();
+
+    void playMusic(std::string path);
+    void pauseMusic(const bool pause) const;
+    void stopMusic();
+private:
+    Mix_Music *current_music = nullptr;
+};
+
+#endif // FILE_SOUND_MANAGER_HPP

--- a/include/brickengine/sound/sound_manager.hpp
+++ b/include/brickengine/sound/sound_manager.hpp
@@ -11,10 +11,10 @@ public:
     ~SoundManager();
 
     void playMusic(std::string path);
-    void pauseMusic(const bool pause) const;
+    void toggleMusic(const bool pause) const;
     void stopMusic();
 private:
-    Mix_Music *current_music = nullptr;
+    Mix_Music* current_music = nullptr;
 };
 
 #endif // FILE_SOUND_MANAGER_HPP

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(SDL2_net REQUIRED)
 find_package(SDL2_gfx REQUIRED)
 find_package(SDL2_ttf REQUIRED)
 find_package(SDL2_image REQUIRED)
+find_package(SDL2_mixer REQUIRED)
 
 add_library(BrickEngine STATIC
     ${BRICKENGINE_SRC_FILES}
@@ -27,6 +28,7 @@ target_link_libraries(BrickEngine
     PRIVATE SDL2::GFX
     PRIVATE SDL2::TTF
     PRIVATE SDL2::Image
+    PRIVATE SDL2::Mixer
 )
 target_compile_features(BrickEngine PUBLIC cxx_std_17)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})

--- a/lib/engine.cpp
+++ b/lib/engine.cpp
@@ -71,6 +71,8 @@ void BrickEngine::start() {
     this->resource_manager = std::make_shared<ResourceManager>(renderer);
     this->renderableFactory = std::unique_ptr<RenderableFactory>(new RenderableFactory(renderer, resource_manager));
 
+    this->sound_manager = std::unique_ptr<SoundManager>(new SoundManager()); 
+
     std::cout << "Window openend finished" << std::endl;
 }
 
@@ -117,6 +119,10 @@ RenderableFactory* BrickEngine::getRenderableFactory() const {
 
 Renderer* BrickEngine::getRenderer() const {
     return this->renderer.get();
+}
+
+SoundManager& BrickEngine::getSoundManager() const {
+    return *this->sound_manager.get();
 }
 
 BrickEngine::EngineTick BrickEngine::getTicks() const {

--- a/lib/sound/sound_manager.cpp
+++ b/lib/sound/sound_manager.cpp
@@ -27,7 +27,7 @@ void SoundManager::playMusic(std::string path) {
     Mix_PlayMusic(current_music, -1); // The -1 is for infinite repeat
 }
 
-void SoundManager::pauseMusic(const bool pause) const {
+void SoundManager::toggleMusic(const bool pause) const {
     if(current_music != nullptr) {
         if(pause) {
             Mix_PauseMusic();

--- a/lib/sound/sound_manager.cpp
+++ b/lib/sound/sound_manager.cpp
@@ -1,0 +1,50 @@
+#include "brickengine/sound/sound_manager.hpp"
+
+#include <iostream>
+#include <string>
+
+#include "SDL2/SDL.h"
+#include "SDL2/SDL_mixer.h"
+
+SoundManager::SoundManager() {
+    if (SDL_Init( SDL_INIT_AUDIO ) != 0) {
+        std::cout << "SDL failed to init! SDL_Error: " << SDL_GetError() << std::endl;
+    }
+
+    //Initialize SDL2_mixer
+    int flags = MIX_INIT_MP3;
+    if(Mix_Init(flags) != flags) {
+        std::cout << "Mixer failed to init! Mix_Error: " << Mix_GetError() << std::endl; 
+    }
+    Mix_OpenAudio(44100, MIX_DEFAULT_FORMAT, 2, 4096);
+}
+
+void SoundManager::playMusic(std::string path) {
+    stopMusic();
+    
+    const std::string full_path = "assets/sound/" + path;
+    current_music = Mix_LoadMUS(full_path.c_str());
+    Mix_PlayMusic(current_music, -1); // The -1 is for infinite repeat
+}
+
+void SoundManager::pauseMusic(const bool pause) const {
+    if(current_music != nullptr) {
+        if(pause) {
+            Mix_PauseMusic();
+        } else {
+            Mix_ResumeMusic();
+        }
+    }
+}
+
+void SoundManager::stopMusic() {
+    if(current_music != nullptr) {
+        // Unload current music
+        Mix_FreeMusic(current_music);
+        current_music = nullptr;
+    }
+}
+
+SoundManager::~SoundManager() {
+    Mix_CloseAudio();
+}


### PR DESCRIPTION
# Description
I implemented SDL_Mixer in the engine.

**MARK PLEASE READ THIS IN CASE YOU FORGOT**
The SoundManager is currently based on the principle of use just wanting to play some background music. Not 2 different tracks, not 3, just 1. Oh, and sound effects will need their own functions but we do not need those.

## Screenshot(s)
_I cannot visualize the sounds_

# How can this be tested?
Combine this PR with the PR from the [game](https://github.com/Brick-Studios/BeastArena/pull/38). The main menu and each level has its own music. Box.json proves that the music loops infinite.

- [x] Have ears
- [x] Play the game through all levels
- [x] Use the ears

**Please listen closely, the SoundManager inits SDL_Mixer with a frequency of 44100 but idk how that sounds your pc's**

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Included 1 or more screenshots
- [X] Code is const correct
