### PR TITLE
Scene manager rework

### DIFF
--- a/include/brickengine/components/component_impl.hpp
+++ b/include/brickengine/components/component_impl.hpp
@@ -4,8 +4,7 @@
 #include "brickengine/components/component.hpp"
 
 template<class ComponentType>
-class ComponentImpl : public Component
-{
+class ComponentImpl : public Component {
 public:
     virtual std::string getName()
     {

--- a/include/brickengine/components/player_component.hpp
+++ b/include/brickengine/components/player_component.hpp
@@ -2,15 +2,17 @@
 #define FILE_PLAYER_COMPONENT_HPP
 
 #include "brickengine/components/component_impl.hpp"
+#include  <string>
 
 class PlayerComponent : public ComponentImpl<PlayerComponent> {
 public:
-    PlayerComponent(int player_id, bool disabled = false);
+    PlayerComponent(int player_id, std::string name, bool disabled = false);
     static std::string getNameStatic();
 
     // Data
     int player_id;
     bool disabled;
+    std::string name;
 };
 
 #endif // FILE_PLAYER_COMPONENT_HPP

--- a/include/brickengine/components/player_component.hpp
+++ b/include/brickengine/components/player_component.hpp
@@ -2,7 +2,7 @@
 #define FILE_PLAYER_COMPONENT_HPP
 
 #include "brickengine/components/component_impl.hpp"
-#include  <string>
+#include <string>
 
 class PlayerComponent : public ComponentImpl<PlayerComponent> {
 public:

--- a/include/brickengine/entities/entity_manager.hpp
+++ b/include/brickengine/entities/entity_manager.hpp
@@ -234,6 +234,13 @@ public:
             return std::set<int>();
         return tagging_tags.at(tag);
     }
+    void removeEntitiesWithTag(std::string tag) {
+        if (!tagging_tags.count(tag)) return;
+
+        for (auto& entity : tagging_tags.at(tag)) {
+            removeEntity(entity);
+        }
+    }
 private:
     int lowest_unassigned_entity_id;
     std::unordered_map<std::string, std::unordered_map<int, std::unique_ptr<Component>>> components_by_class;

--- a/include/brickengine/entities/entity_manager.hpp
+++ b/include/brickengine/entities/entity_manager.hpp
@@ -131,15 +131,17 @@ public:
         moveOutOfParentsHouse(entity_id);
 
         // Remove all those tags
-        if(tagging_entities.count(entity_id)){
-            for (auto& tag : tagging_entities.at(entity_id)) {
+        if(tagging_entities.count(entity_id)) {
+            std::set<std::string> tags_to_delete = tagging_entities.at(entity_id);
+            for (auto& tag : tags_to_delete) {
                 tagging_tags.at(tag).erase(entity_id);
                 tagging_entities.at(entity_id).erase(tag);
             }
         }
 
-        for(auto& component : components_by_class)
+        for(auto& component : components_by_class) {
             component.second.erase(entity_id);
+        }
     }
 
     void setParent(int child_id, int parent_id, bool transform_is_relative) {
@@ -251,9 +253,9 @@ public:
     void removeEntitiesWithTag(std::string tag) {
         if (!tagging_tags.count(tag)) return;
         
-        for (auto& entity : tagging_tags.at(tag)) {
+        std::set<int> entities_to_delete = tagging_tags.at(tag);
+        for (auto& entity : entities_to_delete)
             removeEntity(entity);
-        }
     }
 private:
     int lowest_unassigned_entity_id;

--- a/include/brickengine/entities/entity_manager.hpp
+++ b/include/brickengine/entities/entity_manager.hpp
@@ -131,9 +131,11 @@ public:
         moveOutOfParentsHouse(entity_id);
 
         // Remove all those tags
-        for (auto& tag : tagging_entities.at(entity_id)) {
-            tagging_tags.at(tag).erase(entity_id);
-            tagging_entities.at(entity_id).erase(tag);
+        if(tagging_entities.count(entity_id)){
+            for (auto& tag : tagging_entities.at(entity_id)) {
+                tagging_tags.at(tag).erase(entity_id);
+                tagging_entities.at(entity_id).erase(tag);
+            }
         }
 
         for(auto& component : components_by_class)

--- a/include/brickengine/enum/direction.hpp
+++ b/include/brickengine/enum/direction.hpp
@@ -3,7 +3,7 @@
 
 enum class Direction { 
     POSITIVE, 
-    NEGATIVE 
+    NEGATIVE
 };
 
 #endif //FILE_DIRECTION_HPP

--- a/include/brickengine/exceptions/reset_on_set_state_not_set.hpp
+++ b/include/brickengine/exceptions/reset_on_set_state_not_set.hpp
@@ -1,0 +1,19 @@
+#ifndef FILE_RESET_ON_SET_STATE_NOT_SET_EXCEPTION_HPP
+#define FILE_RESET_ON_SET_STATE_NOT_SET_EXCEPTION_HPP
+
+#include <iostream>
+#include <exception>
+
+template<typename State>
+class ResetOnSetStateNotSetException : public std::exception {
+private:
+  std::string m_msg;
+public:
+  ResetOnSetStateNotSetException(State s) : m_msg(std::string("reset_on_set_state in GameStateManager not correctly set for the upcomming state: ") + std::to_string((int)s)){}
+
+  virtual const char* what() const throw() {
+    return m_msg.c_str();
+  }
+};
+
+#endif // FILE_RESET_ON_SET_STATE_NOT_SET_EXCEPTION_HPP

--- a/include/brickengine/exceptions/state_systems_not_set.hpp
+++ b/include/brickengine/exceptions/state_systems_not_set.hpp
@@ -1,0 +1,19 @@
+#ifndef FILE_STATE_SYSTEMS_NOT_SET_EXCEPTION_HPP
+#define FILE_STATE_SYSTEMS_NOT_SET_EXCEPTION_HPP
+
+#include <iostream>
+#include <exception>
+
+template<typename State>
+class StateSystemsNotSet : public std::exception {
+private:
+  std::string m_msg;
+public:
+  StateSystemsNotSet(State s) : m_msg(std::string("state_systems in GameStateManager not correctly set for the upcomming state: ") + std::to_string((int)s)){}
+
+  virtual const char* what() const throw() {
+    return m_msg.c_str();
+  }
+};
+
+#endif // FILE_STATE_SYSTEMS_NOT_SET_EXCEPTION_HPP

--- a/include/brickengine/game_state_manager.hpp
+++ b/include/brickengine/game_state_manager.hpp
@@ -1,0 +1,34 @@
+#ifndef FILE_GAME_STATE_MANAGER_HPP
+#define FILE_GAME_STATE_MANAGER_HPP
+
+#include <vector>
+#include <unordered_map>
+#include <memory>
+
+#include "brickengine/systems/system.hpp"
+
+template<typename State>
+class GameStateManager {
+public:
+    GameStateManager(std::unordered_map<State, std::unique_ptr<std::vector<System>>> state_systems,
+                     std::unordered_map<State, bool> reset_on_set_state, State begin_state)
+        : state_systems(state_systems), reset_on_set_state(reset_on_set_state), current_state(begin_state) {}
+
+    void setState(State state) {
+        if (reset_on_set_state.at(state)) {
+            for (auto& system : *state_systems.at(state)) {
+                system.reset();
+            }
+        }
+        current_state = state;
+    }
+    std::vector<System>& getSystems() {
+        return *state_systems.at(current_state);
+    }
+private:
+    std::unordered_map<State, std::unique_ptr<std::vector<System>>> state_systems;
+    std::unordered_map<State, bool> reset_on_set_state;
+    State current_state;
+};
+
+#endif // FILE_GAME_STATE_MANAGER_HPP

--- a/include/brickengine/game_state_manager.hpp
+++ b/include/brickengine/game_state_manager.hpp
@@ -23,12 +23,11 @@ public:
             throw ResetOnSetStateNotSetException<State>(state);
         if (!state_systems->count(current_state))
             throw StateSystemsNotSet<State>(state);
-        //if (reset_on_set_state.at(state)) {
-        //    std::vector<std::unique_ptr<System>>* s = state_systems->at(state).get();
-        //    for (auto& system : *s) {
-        //        system.reset();
-        //    }
-        //}
+        if (reset_on_set_state.at(state)) {
+            for (auto& system : *state_systems->at(state)) {
+                system->reset();
+            }
+        }
         current_state = state;
     }
     std::vector<std::unique_ptr<System>>& getSystems() {

--- a/include/brickengine/game_state_manager.hpp
+++ b/include/brickengine/game_state_manager.hpp
@@ -21,7 +21,7 @@ public:
     void setState(State state) {
         if (!reset_on_set_state.count(state))
             throw ResetOnSetStateNotSetException<State>(state);
-        if (!state_systems->count(current_state))
+        if (!state_systems->count(state))
             throw StateSystemsNotSet<State>(state);
         if (reset_on_set_state.at(state)) {
             for (auto& system : *state_systems->at(state)) {

--- a/include/brickengine/rendering/renderable_factory.hpp
+++ b/include/brickengine/rendering/renderable_factory.hpp
@@ -9,7 +9,7 @@
 
 #include <memory>
 
-class RenderableFactory{
+class RenderableFactory {
 public:
     RenderableFactory(std::shared_ptr<Renderer> r, std::shared_ptr<ResourceManager> rm);
     std::unique_ptr<Texture> createText(std::string text, int font_size, Color color, int layer, std::unique_ptr<Rect> dst) const;

--- a/include/brickengine/scenes/enums/scene_layer.hpp
+++ b/include/brickengine/scenes/enums/scene_layer.hpp
@@ -1,0 +1,9 @@
+#ifndef FILE_SCENE_TYPE_HPP
+#define FILE_SCENE_TYPE_HPP
+
+enum class SceneLayer {
+    Primary,
+    Secondary
+};
+
+#endif // FILE_SCENE_TYPE_HPP

--- a/include/brickengine/scenes/exceptions/another_scene_active.hpp
+++ b/include/brickengine/scenes/exceptions/another_scene_active.hpp
@@ -1,0 +1,18 @@
+#ifndef FILE_ANOTHER_SCENE_ACTIVE_EXCEPTION_HPP
+#define FILE_ANOTHER_SCENE_ACTIVE_EXCEPTION_HPP
+
+#include <iostream>
+#include <exception>
+
+class AnotherSceneActiveException : public std::exception {
+private:
+    std::string m_msg;
+public:
+    AnotherSceneActiveException() : m_msg(std::string("Another scene is currently active, destroy it first")){}
+
+    virtual const char* what() const throw() {
+        return m_msg.c_str();
+    }
+};
+
+#endif // FILE_ANOTHER_SCENE_ACTIVE_EXCEPTION_HPP

--- a/include/brickengine/scenes/exceptions/no_scene_active.hpp
+++ b/include/brickengine/scenes/exceptions/no_scene_active.hpp
@@ -1,0 +1,18 @@
+#ifndef FILE_NO_SCENE_ACTIVE_EXCEPTION_HPP
+#define FILE_NO_SCENE_ACTIVE_EXCEPTION_HPP
+
+#include <iostream>
+#include <exception>
+
+class NoSceneActiveException : public std::exception {
+private:
+    std::string m_msg;
+public:
+    NoSceneActiveException() : m_msg(std::string("There is no scene active as the given SceneType.")){}
+
+    virtual const char* what() const throw() {
+        return m_msg.c_str();
+    }
+};
+
+#endif // FILE_NO_SCENE_ACTIVE_EXCEPTION_HPP

--- a/include/brickengine/scenes/scene.hpp
+++ b/include/brickengine/scenes/scene.hpp
@@ -11,31 +11,24 @@
 template<typename State>
 class Scene {
 public:
-    Scene(SceneLayer layer) : layer(layer) {}
+    Scene() = default;
     // Fils the entities
     virtual void prepare() = 0;
     virtual void start() = 0;
     virtual void leave() = 0;
-    virtual State getSystemState() = 0;
-    virtual std::string getTag() = 0;
-    std::optional<std::unique_ptr<std::vector<std::vector<std::unique_ptr<Component>>>>> getEntityComponents() const {
-        if (!entity_components)
-            return std::nullopt;
-        auto r = std::move(*entity_components);
-        entity_components = std::nullopt;
-        return r;
+    virtual State getSystemState() const = 0;
+    virtual std::string getTag() const = 0;
+    virtual SceneLayer getLayer() const = 0;
+    std::unique_ptr<std::vector<std::unique_ptr<std::vector<std::unique_ptr<Component>>>>> getEntityComponents() {
+        return std::move(entity_components);
     }
     bool prepared() const {
-        return entity_components.has_value();
-    }
-    SceneLayer getLayer() const {
-        return layer;
+        return entity_components != nullptr;
     }
     virtual ~Scene() = default;
-private:
-    SceneLayer layer;
-    // If entity_components are nullopt then the Scene has already been loaded or it has not been prepared yet.
-    std::optional<std::unique_ptr<std::vector<std::vector<std::unique_ptr<Component>>>>> entity_components;
+protected:
+    // If entity_components is nullptr then the Scene has already been loaded or it has not been prepared yet.
+    std::unique_ptr<std::vector<std::unique_ptr<std::vector<std::unique_ptr<Component>>>>> entity_components;
 };
 
 #endif // FILE_SCENE_HPP

--- a/include/brickengine/scenes/scene.hpp
+++ b/include/brickengine/scenes/scene.hpp
@@ -7,7 +7,7 @@
 
 #include "brickengine/components/component.hpp"
 
-template<typename State, typename Factory>
+template<typename State>
 class Scene {
 public:
     Scene() = default;
@@ -29,8 +29,6 @@ public:
     }
     virtual ~Scene() = default;
 private:
-    Factory& factory;
-
     // If entity_components are nullopt then the Scene has already been loaded or it has not been prepared yet.
     std::optional<std::unique_ptr<std::vector<std::vector<std::unique_ptr<Component>>>>> entity_components;
 };

--- a/include/brickengine/scenes/scene.hpp
+++ b/include/brickengine/scenes/scene.hpp
@@ -1,0 +1,38 @@
+#ifndef FILE_SCENE_HPP
+#define FILE_SCENE_HPP
+
+#include <optional>
+#include <vector>
+#include <memory>
+
+#include "brickengine/components/component.hpp"
+
+template<typename State, typename Factory>
+class Scene {
+public:
+    Scene() = default;
+    // Fils the entities
+    virtual void prepare() = 0;
+    virtual void start() = 0;
+    virtual void leave() = 0;
+    virtual State getSystemState() = 0;
+    virtual std::string getTag() = 0;
+    std::optional<std::unique_ptr<std::vector<std::vector<std::unique_ptr<Component>>>>> getEntityComponents() const {
+        if (!entity_components)
+            return std::nullopt;
+        auto r = std::move(*entity_components);
+        entity_components = std::nullopt;
+        return r;
+    }
+    bool prepared() const {
+        return entity_components.has_value();
+    }
+    virtual ~Scene() = default;
+private:
+    Factory& factory;
+
+    // If entity_components are nullopt then the Scene has already been loaded or it has not been prepared yet.
+    std::optional<std::unique_ptr<std::vector<std::vector<std::unique_ptr<Component>>>>> entity_components;
+};
+
+#endif // FILE_SCENE_HPP

--- a/include/brickengine/scenes/scene.hpp
+++ b/include/brickengine/scenes/scene.hpp
@@ -13,7 +13,10 @@ class Scene {
 public:
     Scene() = default;
     // Fils the entities
-    virtual void prepare() = 0;
+    void prepare() {
+        performPrepare();
+        prepared = true;
+    }
     virtual void start() = 0;
     virtual void leave() = 0;
     virtual State getSystemState() const = 0;
@@ -22,13 +25,15 @@ public:
     std::unique_ptr<std::vector<std::unique_ptr<std::vector<std::unique_ptr<Component>>>>> getEntityComponents() {
         return std::move(entity_components);
     }
-    bool prepared() const {
-        return entity_components != nullptr;
+    bool isPrepared() const {
+        return prepared;
     }
     virtual ~Scene() = default;
 protected:
-    // If entity_components is nullptr then the Scene has already been loaded or it has not been prepared yet.
+    virtual void performPrepare() = 0;
+    // This can be nullptr as not all scenes actually use entity_components
     std::unique_ptr<std::vector<std::unique_ptr<std::vector<std::unique_ptr<Component>>>>> entity_components;
+    bool prepared;
 };
 
 #endif // FILE_SCENE_HPP

--- a/include/brickengine/scenes/scene.hpp
+++ b/include/brickengine/scenes/scene.hpp
@@ -6,11 +6,12 @@
 #include <memory>
 
 #include "brickengine/components/component.hpp"
+#include "enums/scene_layer.hpp"
 
 template<typename State>
 class Scene {
 public:
-    Scene() = default;
+    Scene(SceneLayer layer) : layer(layer) {}
     // Fils the entities
     virtual void prepare() = 0;
     virtual void start() = 0;
@@ -27,8 +28,12 @@ public:
     bool prepared() const {
         return entity_components.has_value();
     }
+    SceneLayer getLayer() const {
+        return layer;
+    }
     virtual ~Scene() = default;
 private:
+    SceneLayer layer;
     // If entity_components are nullopt then the Scene has already been loaded or it has not been prepared yet.
     std::optional<std::unique_ptr<std::vector<std::vector<std::unique_ptr<Component>>>>> entity_components;
 };

--- a/include/brickengine/scenes/scene.hpp
+++ b/include/brickengine/scenes/scene.hpp
@@ -12,7 +12,7 @@ template<typename State>
 class Scene {
 public:
     Scene() = default;
-    // Fils the entities
+    // Fills the entities
     void prepare() {
         performPrepare();
         prepared = true;

--- a/include/brickengine/scenes/scene.hpp
+++ b/include/brickengine/scenes/scene.hpp
@@ -23,6 +23,7 @@ public:
     virtual std::string getTag() const = 0;
     virtual SceneLayer getLayer() const = 0;
     std::unique_ptr<std::vector<std::unique_ptr<std::vector<std::unique_ptr<Component>>>>> getEntityComponents() {
+        prepared = false;
         return std::move(entity_components);
     }
     bool isPrepared() const {

--- a/include/brickengine/scenes/scene_impl.hpp
+++ b/include/brickengine/scenes/scene_impl.hpp
@@ -4,11 +4,13 @@
 #include "brickengine/scenes/scene.hpp"
 
 template<typename SceneType, typename State>
-class SceneImpl : Scene<State> {
+class SceneImpl : public Scene<State> {
 public:
-    SceneImpl(SceneLayer layer) : Scene<State>(layer) {}
-    virtual std::string getTag() {
+    virtual std::string getTag() const {
         return SceneType::getTagStatic();
+    }
+    virtual SceneLayer getLayer() const {
+        return SceneType::getLayerStatic();
     }
 };
 

--- a/include/brickengine/scenes/scene_impl.hpp
+++ b/include/brickengine/scenes/scene_impl.hpp
@@ -3,11 +3,11 @@
 
 #include "brickengine/scenes/scene.hpp"
 
-template<typename SceneType, typename State, typename Factory>
-class SceneImpl : Scene<State, Factory> {
+template<typename SceneType, typename State>
+class SceneImpl : Scene<State> {
 public:
     virtual std::string getTag() {
-        SceneType::getTagStatic();
+        return SceneType::getTagStatic();
     }
 };
 

--- a/include/brickengine/scenes/scene_impl.hpp
+++ b/include/brickengine/scenes/scene_impl.hpp
@@ -6,6 +6,7 @@
 template<typename SceneType, typename State>
 class SceneImpl : Scene<State> {
 public:
+    SceneImpl(SceneLayer layer) : Scene<State>(layer) {}
     virtual std::string getTag() {
         return SceneType::getTagStatic();
     }

--- a/include/brickengine/scenes/scene_impl.hpp
+++ b/include/brickengine/scenes/scene_impl.hpp
@@ -1,0 +1,14 @@
+#ifndef FILE_SCENE_IMPL_HPP
+#define FILE_SCENE_IMPL_HPP
+
+#include "brickengine/scenes/scene.hpp"
+
+template<typename SceneType, typename State, typename Factory>
+class SceneImpl : Scene<State, Factory> {
+public:
+    virtual std::string getTag() {
+        SceneType::getTagStatic();
+    }
+};
+
+#endif // FILE_SCENE_IMPL_HPP

--- a/include/brickengine/scenes/scene_manager.hpp
+++ b/include/brickengine/scenes/scene_manager.hpp
@@ -1,0 +1,56 @@
+#ifndef FILE_SCENE_MANAGER_HPP
+#define FILE_SCENE_MANAGER_HPP
+
+#include <vector>
+#include <complex>
+#include <memory>
+#include <unordered_map>
+
+#include "brickengine/components/component.hpp"
+#include "brickengine/systems/system.hpp"
+#include "brickengine/scenes/scene.hpp"
+
+template<typename State, typename Factory>
+class SceneManager {
+public:
+    SceneManager(EntityManager& em) : entity_manager(em) {}
+    void loadScene(Scene<State, Factory>& scene) {
+        if (!scene.prepared())
+            scene.prepare();
+        for (auto& entity_comps : scene.getEntityComponents()) {
+            entity_manager.createEntity(std::move(entity_comps));
+        }
+        scene.start();
+        // insert all the new entities.
+    }
+    template <typename T, typename = std::enable_if_t<std::is_base_of_v<Scene, T>>, typename... Args>
+    void loadScene(Args &&... args) {
+        T scene { std::forward<Args>(args)... };
+        scene.prepare();
+        loadScene(scene);
+        scene.start();
+    }
+    template <typename T, typename = std::enable_if_t<std::is_base_of_v<Scene, T>>>
+    void destroyScene() {
+        std::string tag = T::getTagStatic();
+        entity_manager.removeEntitiesWithTag(tag);
+        active_scene_tags.erase(tag);
+    }
+    void destroyAllScenes() {
+        for (std::string& tag : active_scene_tags) {
+            entity_manager.removeEntitiesWithTag(tag);
+        }
+        active_scene_tags.clear();
+    }
+    template <typename T, typename = std::enable_if_t<std::is_base_of_v<Scene, T>>>
+    bool isSceneActive() {
+        std::string tag = T::getTagStatic();
+        return active_scene_tags.count(tag);
+    }
+private:
+    EntityManager& entity_manager;
+
+    std::set<std::string> active_scene_tags;
+};
+
+#endif // FILE_SCENE_MANAGER_HPP

--- a/include/brickengine/scenes/scene_manager.hpp
+++ b/include/brickengine/scenes/scene_manager.hpp
@@ -46,6 +46,7 @@ public:
         if (!scenes.count(layer)) return;
 
         scenes.at(layer)->leave();
+        scenes.at(layer)->leave();
         entity_manager.removeEntitiesWithTag(scenes.at(layer)->getTag());
         scenes.erase(layer);
     }

--- a/include/brickengine/scenes/scene_manager.hpp
+++ b/include/brickengine/scenes/scene_manager.hpp
@@ -9,48 +9,57 @@
 #include "brickengine/components/component.hpp"
 #include "brickengine/systems/system.hpp"
 #include "brickengine/scenes/scene.hpp"
+#include "brickengine/scenes/exceptions/another_scene_active.hpp"
+#include "brickengine/scenes/exceptions/no_scene_active.hpp"
+#include "brickengine/scenes/enums/scene_layer.hpp"
 
 template<typename State>
 class SceneManager {
 public:
     SceneManager(EntityManager& em) : entity_manager(em) {}
-    void loadScene(Scene<State>& scene) {
-        if (!scene.prepared())
-            scene.prepare();
-        for (auto& entity_comps : scene.getEntityComponents()) {
-            entity_manager.createEntity(std::move(entity_comps));
+    void loadScene(std::unique_ptr<Scene<State>> scene) {
+        if (scenes.count(scene->getLayer()))
+            throw AnotherSceneActiveException();
+
+        if (!scene->prepared())
+            scene->prepare();
+        for (auto& entity_comps : scene->getEntityComponents()) {
+            int id = entity_manager.createEntity(std::move(entity_comps));
+            entity_manager.setTag(id, scene.getTag());
         }
-        scene.start();
-        // insert all the new entities.
+        scene->start();
+        scenes.insert({scene->getLayer(), std::move(scene)});
     }
-    template <typename T, typename = std::enable_if_t<std::is_base_of_v<Scene, T>>, typename... Args>
-    void loadScene(Args &&... args) {
-        T scene { std::forward<Args>(args)... };
-        scene.prepare();
-        loadScene(scene);
-        scene.start();
+    template <typename T, typename = std::enable_if_t<std::is_base_of_v<Scene<State>, T>>, typename... Args>
+    void createScene(Args &&... args) {
+        auto scene = std::make_unique<T>(std::forward<Args>(args)...);
+        loadScene(std::move(scene));
     }
-    template <typename T, typename = std::enable_if_t<std::is_base_of_v<Scene, T>>>
-    void destroyScene() {
-        std::string tag = T::getTagStatic();
-        entity_manager.removeEntitiesWithTag(tag);
-        active_scene_tags.erase(tag);
+    void destroyScene(SceneLayer layer) {
+        if (scenes.count(layer)) {
+            scenes.at(layer)->leave();
+            entity_manager.removeEntitiesWithTag(scenes.at(layer)->getTag());
+            scenes.erase(layer);
+        } else {
+            throw NoSceneActiveException();
+        }
     }
     void destroyAllScenes() {
-        for (std::string& tag : active_scene_tags) {
-            entity_manager.removeEntitiesWithTag(tag);
+        for (auto& [ layer, scene ] : scenes) {
+            scene->leave();
+            entity_manager.removeEntitiesWithTag(scene->getTag());
         }
-        active_scene_tags.clear();
+        scenes.clear();
     }
-    template <typename T, typename = std::enable_if_t<std::is_base_of_v<Scene, T>>>
-    bool isSceneActive() {
+    template <typename T, typename = std::enable_if_t<std::is_base_of_v<Scene<State>, T>>>
+    bool isSceneActive(SceneLayer layer) {
         std::string tag = T::getTagStatic();
-        return active_scene_tags.count(tag);
+        return scenes.count(layer);
     }
 private:
     EntityManager& entity_manager;
 
-    std::set<std::string> active_scene_tags;
+    std::unordered_map<SceneLayer, std::unique_ptr<Scene<State>>> scenes;
 };
 
 #endif // FILE_SCENE_MANAGER_HPP

--- a/include/brickengine/scenes/scene_manager.hpp
+++ b/include/brickengine/scenes/scene_manager.hpp
@@ -10,11 +10,11 @@
 #include "brickengine/systems/system.hpp"
 #include "brickengine/scenes/scene.hpp"
 
-template<typename State, typename Factory>
+template<typename State>
 class SceneManager {
 public:
     SceneManager(EntityManager& em) : entity_manager(em) {}
-    void loadScene(Scene<State, Factory>& scene) {
+    void loadScene(Scene<State>& scene) {
         if (!scene.prepared())
             scene.prepare();
         for (auto& entity_comps : scene.getEntityComponents()) {

--- a/include/brickengine/scenes/scene_manager.hpp
+++ b/include/brickengine/scenes/scene_manager.hpp
@@ -5,6 +5,7 @@
 #include <complex>
 #include <memory>
 #include <unordered_map>
+#include <functional>
 
 #include "brickengine/components/component.hpp"
 #include "brickengine/systems/system.hpp"
@@ -12,37 +13,44 @@
 #include "brickengine/scenes/exceptions/another_scene_active.hpp"
 #include "brickengine/scenes/exceptions/no_scene_active.hpp"
 #include "brickengine/scenes/enums/scene_layer.hpp"
+#include "brickengine/game_state_manager.hpp"
 
 template<typename State>
 class SceneManager {
 public:
-    SceneManager(EntityManager& em) : entity_manager(em) {}
+    SceneManager(EntityManager& em, GameStateManager<State>& gsm) : entity_manager(em), game_state_manager(gsm) {}
     void loadScene(std::unique_ptr<Scene<State>> scene) {
         if (scenes.count(scene->getLayer()))
             throw AnotherSceneActiveException();
-
-        if (!scene->prepared())
-            scene->prepare();
-        for (auto& entity_comps : scene->getEntityComponents()) {
-            int id = entity_manager.createEntity(std::move(entity_comps));
-            entity_manager.setTag(id, scene.getTag());
-        }
-        scene->start();
+        Scene<State>& scene_ref = *scene;
+        // We need to insert the scene asap, because the entity manager will try to fetch the current scene tag when creating new entities
         scenes.insert({scene->getLayer(), std::move(scene)});
+
+        if (!scene_ref.prepared()) {
+            std::cout << "I am preparing 🧒" << std::endl;
+            scene_ref.prepare();
+            
+        }
+        auto entity_comps = scene_ref.getEntityComponents();
+        if (entity_comps) {
+            for (auto& entity_comps : *entity_comps) {
+                entity_manager.createEntity(std::move(entity_comps), std::nullopt, scene_ref.getTag());
+            }
+        }
+        scene_ref.start();
+        game_state_manager.setState(scene_ref.getSystemState());
     }
-    template <typename T, typename = std::enable_if_t<std::is_base_of_v<Scene<State>, T>>, typename... Args>
+    template <typename T, typename... Args, typename = std::enable_if_t<std::is_base_of_v<Scene<State>, T>>>
     void createScene(Args &&... args) {
         auto scene = std::make_unique<T>(std::forward<Args>(args)...);
         loadScene(std::move(scene));
     }
     void destroyScene(SceneLayer layer) {
-        if (scenes.count(layer)) {
-            scenes.at(layer)->leave();
-            entity_manager.removeEntitiesWithTag(scenes.at(layer)->getTag());
-            scenes.erase(layer);
-        } else {
-            throw NoSceneActiveException();
-        }
+        if (!scenes.count(layer)) return;
+
+        scenes.at(layer)->leave();
+        entity_manager.removeEntitiesWithTag(scenes.at(layer)->getTag());
+        scenes.erase(layer);
     }
     void destroyAllScenes() {
         for (auto& [ layer, scene ] : scenes) {
@@ -52,12 +60,25 @@ public:
         scenes.clear();
     }
     template <typename T, typename = std::enable_if_t<std::is_base_of_v<Scene<State>, T>>>
-    bool isSceneActive(SceneLayer layer) {
-        std::string tag = T::getTagStatic();
-        return scenes.count(layer);
+    bool isSceneActive() {
+        if (scenes.count(T::getLayerStatic()))
+            return scenes.at(T::getLayerStatic())->getTag() == T::getTagStatic();
+        return false;
+    }
+    std::string getLayerTag(SceneLayer layer) const {
+        return scenes.at(layer)->getTag();
+    }
+    std::function<std::optional<std::string>()> createGetPrimaryTagFunction() const {
+        return [sm = this]() -> std::optional<std::string> {
+            if (sm->scenes.count(SceneLayer::Primary))
+                return sm->scenes.at(SceneLayer::Primary)->getTag();
+            else
+                return std::nullopt;
+        };
     }
 private:
     EntityManager& entity_manager;
+    GameStateManager<State>& game_state_manager;
 
     std::unordered_map<SceneLayer, std::unique_ptr<Scene<State>>> scenes;
 };

--- a/include/brickengine/scenes/scene_manager.hpp
+++ b/include/brickengine/scenes/scene_manager.hpp
@@ -26,11 +26,8 @@ public:
         // We need to insert the scene asap, because the entity manager will try to fetch the current scene tag when creating new entities
         scenes.insert({scene->getLayer(), std::move(scene)});
 
-        if (!scene_ref.prepared()) {
-            std::cout << "I am preparing 🧒" << std::endl;
+        if (!scene_ref.isPrepared())
             scene_ref.prepare();
-            
-        }
         auto entity_comps = scene_ref.getEntityComponents();
         if (entity_comps) {
             for (auto& entity_comps : *entity_comps) {

--- a/include/brickengine/systems/system.hpp
+++ b/include/brickengine/systems/system.hpp
@@ -3,11 +3,12 @@
 
 #include "brickengine/entities/entity_manager.hpp"
 
-class System{
+class System {
 public:
     System(std::shared_ptr<EntityManager> _entityManager) : entityManager(_entityManager) {}
     virtual ~System() = default;
     virtual void update(double deltatime) = 0;
+    virtual void reset() {};
 protected:
     std::shared_ptr<EntityManager> entityManager;
 };

--- a/lib/components/player_component.cpp
+++ b/lib/components/player_component.cpp
@@ -1,7 +1,7 @@
 #include "brickengine/components/player_component.hpp"
 
-PlayerComponent::PlayerComponent(int player_id, bool disabled)
-    : player_id(player_id), disabled(disabled) {}
+PlayerComponent::PlayerComponent(int player_id, std::string name, bool disabled)
+    : player_id(player_id), disabled(disabled), name(name) {}
 
 std::string PlayerComponent::getNameStatic() {
     return "PlayerComponent";

--- a/tests/entities/entity_manager_test.cpp
+++ b/tests/entities/entity_manager_test.cpp
@@ -84,7 +84,7 @@ TEST(EntityManager, create_entities_and_remove_entity) {
 
     auto entities = em.getEntitiesByComponent<TransformComponent>();
 
-    EXPECT_EQ(1, 1);
+    EXPECT_EQ(1, entities.size());
 }
 
 TEST(EntityManager, create_entities_and_add_component) {

--- a/tests/entities/entity_manager_test.cpp
+++ b/tests/entities/entity_manager_test.cpp
@@ -84,8 +84,7 @@ TEST(EntityManager, create_entities_and_remove_entity) {
 
     auto entities = em.getEntitiesByComponent<TransformComponent>();
 
-    
-    EXPECT_EQ(1, entities.size());
+    EXPECT_EQ(1, 1);
 }
 
 TEST(EntityManager, create_entities_and_add_component) {
@@ -97,7 +96,7 @@ TEST(EntityManager, create_entities_and_add_component) {
         id = em.createEntity(std::move(comps), std::nullopt);
     }
     {
-        em.addComponentToEntity(id, std::make_unique<PlayerComponent>(0));
+        em.addComponentToEntity(id, std::make_unique<PlayerComponent>(0, "Panda 1"));
     }
 
     auto entities = em.getEntitiesByComponent<PlayerComponent>();


### PR DESCRIPTION
# Description

### Scene Manager Rework
Our new Scene can be built the _correct way_ by filling a **vector<vector<Component>>**, the first vector represents the different entities and the second are the components for said entity. The SceneManager will then, create the entities for you. But it can also be built using the old way by creating structs and when the start function gets called on the scene, create scene has three methods: 
- prepare(): Create the components or create the structs.
- start(): Does things like teleporting the players to the correct start positions and if the Scene is built using the old way, it will create the entities from the created structs in prepared.
- leave(): Do things like disabling the players and moving them out of the screen.

The way scenes are created has changed. A component-like polymorphism is used with SceneImpl, which allows you to staticly or with an instance get the tag and scene layer. The tag is used to determine under which tag the entities should be created, so that they can be destroyed on scene destroy. The layer is used to determine whether the scene is a "primary" or "secondary" scene. A primary scene is something like a main menu or a game level, secondary scene is an overlay like a pause menu. This layer enum is defined in the engine, as this currently is how it can determine in which scene to put new entities.
When a new entity gets created, it will either go into a given scene tag(like when the scene is loaded by the SceneManager) or into the current primary scene.


### GameStateManager
- You can provide your own state enum to the GameStateManager, it will keep track of a current state and return the currently to execute systems for the state. The GameController will execute these current systems every frame. This should be quite performant because of the hashmap and passing of references.
- With reset_on_set_state you can configure whether when a state gets activated if the systems should be reset, resetting a system means putting it's data to it's default values.

# How can this be tested?
- [ ] The game can be fully played until the main menu. 
- [ ] The game can be played multiple times without leaving textures from previous scenes on the screen.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] Any dependent changes have been merged and published in downstream modules
- [X] Code is const correct
