### PR TITLE
Fixed segfault when lots of entities have physics

### DIFF
--- a/include/brickengine/enum/direction.hpp
+++ b/include/brickengine/enum/direction.hpp
@@ -2,8 +2,31 @@
 #define FILE_DIRECTION_HPP
 
 enum class Direction { 
-    POSITIVE, 
-    NEGATIVE
+    POSITIVE = 0, 
+    NEGATIVE = 1
+};
+
+#include <iostream>
+#include <exception>
+
+class UnknownDirectionException : public std::exception {
+private:
+  std::string m_msg;
+public:
+  UnknownDirectionException(int layer) : m_msg(std::string("The entered direction ") + std::to_string(layer) + std::string(" is not supported")){}
+
+  virtual const char* what() const throw() {
+    return m_msg.c_str();
+  }
+};
+
+class DirectionConverter {
+public:
+    static Direction convertInt(int i) {
+        if (i < 0 || i > 8)
+            throw UnknownDirectionException(i);
+        return static_cast<Direction>(i);
+    }
 };
 
 #endif //FILE_DIRECTION_HPP

--- a/include/brickengine/enum/direction.hpp
+++ b/include/brickengine/enum/direction.hpp
@@ -23,7 +23,7 @@ public:
 class DirectionConverter {
 public:
     static Direction convertInt(int i) {
-        if (i < 0 || i > 8)
+        if (i < 0 || i > 1)
             throw UnknownDirectionException(i);
         return static_cast<Direction>(i);
     }

--- a/lib/sound/sound_manager.cpp
+++ b/lib/sound/sound_manager.cpp
@@ -46,12 +46,8 @@ void SoundManager::stopMusic() {
 }
 
 bool SoundManager::isPlaying() const {
-    if(current_music != nullptr) {
-        if(Mix_PlayingMusic() == 1) {
-            return true;
-        }
-    }
-    return false;
+    if (current_music == nullptr) return false;
+    return Mix_PlayingMusic() == 1;
 }
 
 SoundManager::~SoundManager() {

--- a/lib/systems/physics_system.cpp
+++ b/lib/systems/physics_system.cpp
@@ -15,14 +15,11 @@ void PhysicsSystem::update(double deltatime) {
 
     std::for_each(entities_with_physics.begin(), entities_with_physics.end(), [](const auto& lhs) {
         auto& lhs_physics = lhs.second;
-        std::cout << &lhs_physics->collision_detection << std::endl;
     });
 
     std::stable_sort(entities_with_physics.begin(), entities_with_physics.end(), [](const auto& lhs, const auto& rhs) {
         auto& lhs_physics = lhs.second;
         auto& rhs_physics = rhs.second;
-        std::cout << &lhs_physics->collision_detection << std::endl;
-        std::cout << &rhs_physics->collision_detection << std::endl;
         return (lhs_physics->collision_detection.isDiscrete() && !lhs_physics->collision_detection.isContinuous()) > !rhs_physics->collision_detection.isDiscrete();
     });
 

--- a/lib/systems/physics_system.cpp
+++ b/lib/systems/physics_system.cpp
@@ -13,10 +13,6 @@ PhysicsSystem::PhysicsSystem(CollisionDetector2& cd, std::shared_ptr<EntityManag
 void PhysicsSystem::update(double deltatime) {
     auto entities_with_physics = entityManager->getEntitiesByComponent<PhysicsComponent>();
 
-    std::for_each(entities_with_physics.begin(), entities_with_physics.end(), [](const auto& lhs) {
-        auto& lhs_physics = lhs.second;
-    });
-
     std::stable_sort(entities_with_physics.begin(), entities_with_physics.end(), [](const auto& lhs, const auto& rhs) {
         auto& lhs_physics = lhs.second;
         auto& rhs_physics = rhs.second;

--- a/lib/systems/physics_system.cpp
+++ b/lib/systems/physics_system.cpp
@@ -13,9 +13,16 @@ PhysicsSystem::PhysicsSystem(CollisionDetector2& cd, std::shared_ptr<EntityManag
 void PhysicsSystem::update(double deltatime) {
     auto entities_with_physics = entityManager->getEntitiesByComponent<PhysicsComponent>();
 
-    std::sort(entities_with_physics.begin(), entities_with_physics.end(), [](const auto& lhs, const auto& rhs) -> bool {
-        auto lhs_physics = lhs.second;
-        auto rhs_physics = rhs.second;
+    std::for_each(entities_with_physics.begin(), entities_with_physics.end(), [](const auto& lhs) {
+        auto& lhs_physics = lhs.second;
+        std::cout << &lhs_physics->collision_detection << std::endl;
+    });
+
+    std::stable_sort(entities_with_physics.begin(), entities_with_physics.end(), [](const auto& lhs, const auto& rhs) {
+        auto& lhs_physics = lhs.second;
+        auto& rhs_physics = rhs.second;
+        std::cout << &lhs_physics->collision_detection << std::endl;
+        std::cout << &rhs_physics->collision_detection << std::endl;
         return (lhs_physics->collision_detection.isDiscrete() && !lhs_physics->collision_detection.isContinuous()) > !rhs_physics->collision_detection.isDiscrete();
     });
 


### PR DESCRIPTION
# Description

I have no clue why using stable sort instead of unstable sort works, but this bug is really weird. It works, so :woman_shrugging: 

# How can this be tested?

Spawn tons and tons of weapons, does it crash? No? It works.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Included 1 or more screenshots
- [x] Code is const correct
